### PR TITLE
修复在解析某种特殊的订阅信息时的问题

### DIFF
--- a/src/main/config/profile.ts
+++ b/src/main/config/profile.ts
@@ -227,10 +227,10 @@ function parseFilename(str: string): string {
 
 // subscription-userinfo: upload=1234; download=2234; total=1024000; expire=2218532293
 function parseSubinfo(str: string): ISubscriptionUserInfo {
-  const parts = str.split('; ')
+  const parts = str.split(';')
   const obj = {} as ISubscriptionUserInfo
   parts.forEach((part) => {
-    const [key, value] = part.split('=')
+    const [key, value] = part.trim().split('=')
     obj[key] = parseInt(value)
   })
   return obj


### PR DESCRIPTION
`subscription-userinfo: upload=135182417;download=16268363038;total=21474836480;expire=2145916800`
在解析如上分号后未跟空格的情况下，目前的解析方式无法正确解析，这个拉取请求是想要修复这个问题的。