### PR TITLE
fix(proxies): 修复代理组更新与嵌套分组显示问题

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -98,6 +98,10 @@
 !macroend
 
 !macro customInstall
+  ${ifNot} ${isUpdated}
+    CreateShortcut "$DESKTOP\${PRODUCT_FILENAME}.lnk" "$INSTDIR\${PRODUCT_FILENAME}.exe"
+  ${endIf}
+
   ${If} $sparkleServiceWasRunning == "true"
     StrCpy $R1 "$INSTDIR\resources\files\sparkle-service.exe"
     ${If} ${FileExists} "$R1"

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -35,7 +35,8 @@ nsis:
   allowToChangeInstallationDirectory: true
   oneClick: false
   perMachine: true
-  createDesktopShortcut: true
+  createDesktopShortcut: false
+  include: build/installer.nsh
 mac:
   target:
     - pkg

--- a/src/main/resolve/autoUpdater.ts
+++ b/src/main/resolve/autoUpdater.ts
@@ -149,7 +149,7 @@ export async function downloadAndInstallUpdate(version: string): Promise<void> {
 
     await triggerSysProxy(false, false)
     if (file.endsWith('.exe')) {
-      spawn(path.join(dataDir(), file), ['/S', '--force-run'], {
+      spawn(path.join(dataDir(), file), ['/S', '--updated', '--force-run'], {
         detached: true,
         stdio: 'ignore'
       }).unref()

--- a/src/main/utils/template.ts
+++ b/src/main/utils/template.ts
@@ -52,6 +52,7 @@ export const defaultConfig: AppConfig = {
   disableGPU: process.platform === 'win32' && parseInt(os.release().split('.')[2], 10) <= 20000,
   proxyDisplayLayout: 'double',
   groupDisplayLayout: 'double',
+  showGroupSelectedProxy: true,
   autoLightweightMode: 'core',
   coreStartupMode: 'post-up',
   delayTestConcurrency: 50,

--- a/src/renderer/src/components/proxies/proxy-item.tsx
+++ b/src/renderer/src/components/proxies/proxy-item.tsx
@@ -7,15 +7,31 @@ interface Props {
   mutateProxies: () => void
   onProxyDelay: (proxy: string, group?: ControllerMixedGroup) => Promise<ControllerProxiesDelay>
   proxyDisplayLayout: 'hidden' | 'single' | 'double'
+  showGroupSelectedProxy: boolean
   proxy: ControllerProxiesDetail | ControllerGroupDetail
   group: ControllerMixedGroup
   onSelect: (group: string, proxy: string) => void
   selected: boolean
 }
 
+const isGroup = (
+  proxy: ControllerProxiesDetail | ControllerGroupDetail
+): proxy is ControllerGroupDetail => {
+  return 'now' in proxy && typeof (proxy as ControllerGroupDetail).now === 'string'
+}
+
 const ProxyItem: React.FC<Props> = (props) => {
-  const { mutateProxies, proxyDisplayLayout, group, proxy, selected, onSelect, onProxyDelay } =
-    props
+  const {
+    mutateProxies,
+    proxyDisplayLayout,
+    showGroupSelectedProxy,
+    group,
+    proxy,
+    selected,
+    onSelect,
+    onProxyDelay
+  } = props
+  const shouldShowGroupSelectedProxy = showGroupSelectedProxy && isGroup(proxy) && Boolean(proxy.now)
 
   const delay = useMemo(() => {
     if (proxy.history.length > 0) {
@@ -72,6 +88,14 @@ const ProxyItem: React.FC<Props> = (props) => {
                 </div>
                 <div className="text-[12px] text-foreground-500 leading-none mt-0.5">
                   <span>{proxy.type}</span>
+                  {shouldShowGroupSelectedProxy && (
+                    <>
+                      <span className="mx-1">→</span>
+                      <span className="flag-emoji" title={proxy.now}>
+                        {proxy.now}
+                      </span>
+                    </>
+                  )}
                 </div>
               </div>
               <div className="flex items-center justify-center gap-0.5 shrink-0">
@@ -106,7 +130,16 @@ const ProxyItem: React.FC<Props> = (props) => {
               <div className="text-ellipsis overflow-hidden whitespace-nowrap">
                 <div className="flag-emoji inline">{proxy.name}</div>
                 {proxyDisplayLayout === 'single' && (
-                  <div className="inline ml-2 text-foreground-500">{proxy.type}</div>
+                  <>
+                    <div className="inline ml-2 text-foreground-500" title={proxy.type}>
+                      {proxy.type}
+                    </div>
+                    {shouldShowGroupSelectedProxy && (
+                      <div className="inline ml-2 text-foreground-500 flag-emoji" title={proxy.now}>
+                        → {proxy.now}
+                      </div>
+                    )}
+                  </>
                 )}
               </div>
               <div className="flex items-center gap-0.5 shrink-0">

--- a/src/renderer/src/components/proxies/proxy-setting-modal.tsx
+++ b/src/renderer/src/components/proxies/proxy-setting-modal.tsx
@@ -24,6 +24,7 @@ const ProxySettingModal: React.FC<Props> = (props) => {
     proxyDisplayOrder = 'default',
     groupDisplayLayout = 'single',
     proxyDisplayLayout = 'double',
+    showGroupSelectedProxy = true,
     autoCloseConnection = true,
     closeMode = 'all',
     delayTestUrl,
@@ -150,6 +151,19 @@ const ProxySettingModal: React.FC<Props> = (props) => {
                     })
                   }}
                 />
+              </SettingItem>
+              <SettingItem title="显示二级分组选中节点" {...settingItemProps} divider>
+                <Switch
+                  aria-label="显示二级分组选中节点"
+                  isSelected={showGroupSelectedProxy}
+                  onChange={(v) => {
+                    patchAppConfig({ showGroupSelectedProxy: v })
+                  }}
+                >
+                  <Switch.Control>
+                    <Switch.Thumb />
+                  </Switch.Control>
+                </Switch>
               </SettingItem>
               <SettingItem title="切换节点时断开连接" {...settingItemProps} divider>
                 <Switch

--- a/src/renderer/src/pages/proxies.tsx
+++ b/src/renderer/src/pages/proxies.tsx
@@ -163,6 +163,7 @@ const Proxies: React.FC = () => {
   const {
     proxyDisplayLayout = 'double',
     groupDisplayLayout = 'double',
+    showGroupSelectedProxy = true,
     proxyDisplayOrder = 'default',
     autoCloseConnection = true,
     closeMode = 'all',
@@ -464,6 +465,8 @@ const Proxies: React.FC = () => {
   onChangeProxyRef.current = onChangeProxy
   const proxyDisplayLayoutRef = useRef(proxyDisplayLayout)
   proxyDisplayLayoutRef.current = proxyDisplayLayout
+  const showGroupSelectedProxyRef = useRef(showGroupSelectedProxy)
+  showGroupSelectedProxyRef.current = showGroupSelectedProxy
   const proxyCols2Ref = useRef(proxyCols)
   proxyCols2Ref.current = proxyCols
   const toggleOpenRef = useRef(toggleOpen)
@@ -528,6 +531,7 @@ const Proxies: React.FC = () => {
     const c = colsRef.current
     const pCols = proxyCols2Ref.current
     const pLayout = proxyDisplayLayoutRef.current
+    const showGroupSelected = showGroupSelectedProxyRef.current
     let innerIndex = index
     for (let i = 0; i < groupIndex; i++) {
       innerIndex -= gc[i]
@@ -546,6 +550,7 @@ const Proxies: React.FC = () => {
           proxy={proxy}
           group={grps[groupIndex]}
           proxyDisplayLayout={pLayout}
+          showGroupSelectedProxy={showGroupSelected}
           selected={proxy.name === grps[groupIndex].now}
         />
       )

--- a/src/shared/types/app.d.ts
+++ b/src/shared/types/app.d.ts
@@ -33,6 +33,7 @@ interface AppConfig {
   proxyDisplayOrder: 'default' | 'delay' | 'name'
   proxyDisplayLayout: 'hidden' | 'single' | 'double'
   groupDisplayLayout: 'hidden' | 'single' | 'double'
+  showGroupSelectedProxy: boolean
   profileDisplayDate?: 'expire' | 'update'
   envType?: ('bash' | 'fish' | 'cmd' | 'powershell' | 'nushell')[]
   proxyCols: 'auto' | '1' | '2' | '3' | '4'


### PR DESCRIPTION
- 修复 Windows 软件内更新后重复创建桌面快捷方式的问题
- 支持在二级/嵌套代理组中显示当前选中的下级节点

Closes #206
Closes #205