### PR TITLE
fix: macOS 标题栏标题绝对居中

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -457,30 +457,30 @@ const App: React.FC = () => {
           <div
             className={`app-drag sticky top-0 z-40 ${disableAnimation ? 'bg-background/95 backdrop-blur-sm' : 'bg-transparent backdrop-blur'} h-12.25`}
           >
-            <div
-              className={`flex justify-between p-2 ${!useWindowFrame && platform === 'darwin' ? 'ml-15' : ''}`}
-            >
-              <div className="flex ml-1">
-                <h3 className="text-lg font-bold leading-8">Sparkle</h3>
+            <div className="relative p-2 h-8">
+              <h3 className="absolute left-1/2 -translate-x-1/2 text-lg font-bold leading-8">
+                Sparkle
+              </h3>
+              <div className="absolute right-2 flex gap-2">
+                {latest && latest.version && (
+                  <UpdaterButton
+                    latest={latest}
+                    showButtonAfterNotification={showUpdateButtonAfterNotification}
+                  />
+                )}
+                <Button
+                  size="sm"
+                  className="app-nodrag"
+                  isIconOnly
+                  color={location.pathname.includes('/settings') ? 'primary' : 'default'}
+                  variant={location.pathname.includes('/settings') ? 'solid' : 'light'}
+                  onPress={() => {
+                    navigate('/settings')
+                  }}
+                >
+                  <IoSettings className="text-[20px]" />
+                </Button>
               </div>
-              {latest && latest.version && (
-                <UpdaterButton
-                  latest={latest}
-                  showButtonAfterNotification={showUpdateButtonAfterNotification}
-                />
-              )}
-              <Button
-                size="sm"
-                className="app-nodrag"
-                isIconOnly
-                color={location.pathname.includes('/settings') ? 'primary' : 'default'}
-                variant={location.pathname.includes('/settings') ? 'solid' : 'light'}
-                onPress={() => {
-                  navigate('/settings')
-                }}
-              >
-                <IoSettings className="text-[20px]" />
-              </Button>
             </div>
           </div>
           <div className="mt-2 mx-2">


### PR DESCRIPTION
## 变更说明

macOS 下不使用系统标题栏时，标题 Sparkle 当前通过 `ml-15` 避开红黄绿按钮，导致标题不是真正居中。

## 修改内容

- 移除 `ml-15` 偏移
- 标题使用 `absolute left-1/2 -translate-x-1/2` 实现绝对居中
- 右侧按钮（更新按钮、设置按钮）保持靠右对齐
- 保持 `app-drag` 拖拽区域功能不变

## 测试

- [x] TypeScript 类型检查通过
- [x] ESLint 检查通过