### PR TITLE
fix: improve PrtScn compatibility for elevated Windows windows

### DIFF
--- a/scripts/prepare.ts
+++ b/scripts/prepare.ts
@@ -7,6 +7,10 @@ import { execSync } from 'child_process'
 
 const cwd = process.cwd()
 const TEMP_DIR = path.join(cwd, 'node_modules/.temp')
+const PRTSCN_HOOK_FILE = 'prtscnhook.node'
+const PRTSCN_HOOK_SOURCE = path.join(cwd, 'src', 'main', 'sys', 'win32', 'prtscnhook.cpp')
+const PRTSCN_HELPER_FILE = 'prtscnhelper.exe'
+const PRTSCN_HELPER_SOURCE = path.join(cwd, 'src', 'main', 'sys', 'win32', 'prtscnhelper.cpp')
 let arch: string = process.arch
 const platform = process.platform
 if (process.argv.slice(2).length !== 0) {
@@ -310,6 +314,177 @@ const resolveRunner = () =>
     downloadURL: `https://github.com/xishang0128/sparkle-run/releases/download/${arch}/sparkle-run.exe`
   })
 
+function quoteCmdArg(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`
+}
+
+function getVcTargetArch(): string {
+  switch (arch) {
+    case 'x64':
+      return 'x64'
+    case 'ia32':
+      return 'x86'
+    case 'arm64':
+      return 'x64_arm64'
+    default:
+      throw new Error(`unsupported windows helper architecture "${arch}"`)
+  }
+}
+
+function getVisualStudioVarsPath(): string {
+  const programFilesX86 = process.env['ProgramFiles(x86)']
+  if (!programFilesX86) {
+    throw new Error('ProgramFiles(x86) is unavailable')
+  }
+
+  const vswherePath = path.join(
+    programFilesX86,
+    'Microsoft Visual Studio',
+    'Installer',
+    'vswhere.exe'
+  )
+  if (!fs.existsSync(vswherePath)) {
+    throw new Error('vswhere.exe not found')
+  }
+
+  const installationPath = execSync(
+    `${quoteCmdArg(vswherePath)} -latest -products * -property installationPath`,
+    { encoding: 'utf8' }
+  ).trim()
+  const vcvarsPath = path.join(installationPath, 'VC', 'Auxiliary', 'Build', 'vcvarsall.bat')
+  if (!fs.existsSync(vcvarsPath)) {
+    throw new Error('vcvarsall.bat not found')
+  }
+
+  return vcvarsPath
+}
+
+function getPrtScnHookBuildArgs(targetPath: string): string[] {
+  return [
+    '/nologo',
+    '/O1',
+    '/GL',
+    '/GS-',
+    '/GR-',
+    '/EHs-c-',
+    '/DUNICODE',
+    '/D_UNICODE',
+    `/Fe:${targetPath}`,
+    `/Fo:${path.join(TEMP_DIR, 'prtscnhook.obj')}`,
+    PRTSCN_HOOK_SOURCE,
+    'user32.lib',
+    'kernel32.lib',
+    'advapi32.lib',
+    '/link',
+    '/DLL',
+    '/LTCG',
+    '/NOENTRY',
+    '/NOIMPLIB',
+    '/NODEFAULTLIB',
+    '/OPT:REF',
+    '/OPT:ICF'
+  ]
+}
+
+function getPrtScnHelperBuildArgs(targetPath: string): string[] {
+  return [
+    '/nologo',
+    '/O1',
+    '/GL',
+    '/GS-',
+    '/GR-',
+    '/EHs-c-',
+    '/DUNICODE',
+    '/D_UNICODE',
+    `/Fe:${targetPath}`,
+    `/Fo:${path.join(TEMP_DIR, 'prtscnhelper.obj')}`,
+    PRTSCN_HELPER_SOURCE,
+    'user32.lib',
+    'kernel32.lib',
+    'advapi32.lib',
+    '/link',
+    '/SUBSYSTEM:WINDOWS',
+    '/ENTRY:wWinMainCRTStartup',
+    '/LTCG',
+    '/NODEFAULTLIB',
+    '/OPT:REF',
+    '/OPT:ICF'
+  ]
+}
+
+function formatClArgForCmd(arg: string): string {
+  if (arg.startsWith('/Fe:') || arg.startsWith('/Fo:')) {
+    return `${arg.slice(0, 4)}${quoteCmdArg(arg.slice(4))}`
+  }
+
+  return /[\s&()]/.test(arg) ? quoteCmdArg(arg) : arg
+}
+
+function buildWithMsvc(args: string[]): void {
+  const clCommand = ['cl.exe', ...args.map(formatClArgForCmd)].join(' ')
+  try {
+    execSync(clCommand, { stdio: 'inherit' })
+    return
+  } catch (error) {
+    console.warn(`[WARN]: cl.exe failed in current shell: ${getErrorMessage(error)}`)
+  }
+
+  const vcvarsPath = getVisualStudioVarsPath()
+  const command = [
+    'call',
+    quoteCmdArg(vcvarsPath),
+    getVcTargetArch(),
+    '>nul',
+    '&&',
+    'cl.exe',
+    ...args.map(formatClArgForCmd)
+  ].join(' ')
+
+  execSync(command, { stdio: 'inherit' })
+}
+
+function buildPrtScnHook(targetPath: string): void {
+  buildWithMsvc(getPrtScnHookBuildArgs(targetPath))
+}
+
+function buildPrtScnHelper(targetPath: string): void {
+  buildWithMsvc(getPrtScnHelperBuildArgs(targetPath))
+}
+
+function removePrtScnHookBuildArtifact(targetPath: string, extension: string): void {
+  const artifactPath = path.join(
+    path.dirname(targetPath),
+    `${path.basename(targetPath, path.extname(targetPath))}${extension}`
+  )
+
+  if (fs.existsSync(artifactPath)) {
+    fs.rmSync(artifactPath)
+  }
+}
+
+async function resolvePrtScnHook() {
+  const targetDir = path.join(cwd, 'extra', 'files')
+  const hookPath = path.join(targetDir, PRTSCN_HOOK_FILE)
+  const helperPath = path.join(targetDir, PRTSCN_HELPER_FILE)
+
+  fs.mkdirSync(TEMP_DIR, { recursive: true })
+  fs.mkdirSync(targetDir, { recursive: true })
+  if (fs.existsSync(hookPath)) {
+    fs.rmSync(hookPath)
+  }
+  if (fs.existsSync(helperPath)) {
+    fs.rmSync(helperPath)
+  }
+
+  buildPrtScnHook(hookPath)
+  removePrtScnHookBuildArtifact(hookPath, '.exp')
+  removePrtScnHookBuildArtifact(hookPath, '.lib')
+  console.log(`[INFO]: ${PRTSCN_HOOK_FILE} finished`)
+
+  buildPrtScnHelper(helperPath)
+  console.log(`[INFO]: ${PRTSCN_HELPER_FILE} finished`)
+}
+
 const resolveMonitor = async () => {
   const tempDir = path.join(TEMP_DIR, 'TrafficMonitor')
   const tempZip = path.join(tempDir, `${arch}.zip`)
@@ -446,6 +621,12 @@ const tasks: Task[] = [
     name: 'runner',
     func: resolveRunner,
     retry: 5,
+    winOnly: true
+  },
+  {
+    name: 'prtScnHook',
+    func: resolvePrtScnHook,
+    retry: 1,
     winOnly: true
   },
   {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -20,6 +20,7 @@ import {
   ensureWindowsElevatedStartup,
   useLinuxCustomRelaunch
 } from './sys/startup'
+import { installPrintScreenCompatibility } from './sys/printScreen'
 import { handleDeepLink } from './resolve/deepLink'
 import { initAppQuitLifecycle } from './resolve/appLifecycle'
 import { showNotification } from './utils/notification'
@@ -259,6 +260,7 @@ export async function createWindow(appConfig?: AppConfig): Promise<void> {
         ...(is.dev ? { webSecurity: false } : {})
       }
     })
+    installPrintScreenCompatibility(mainWindow)
     windowStateManager.attach(mainWindow)
     mainWindow.on('ready-to-show', async () => {
       const { silentStart = false } = await getAppConfig()

--- a/src/main/sys/printScreen.ts
+++ b/src/main/sys/printScreen.ts
@@ -1,0 +1,286 @@
+import type { BrowserWindow } from 'electron'
+import { createRequire } from 'module'
+import path from 'path'
+import { getAppConfig } from '../config'
+import { appendAppLog } from '../utils/log'
+import { resourcesFilesDir } from '../utils/dirs'
+import { isRunningAsAdmin } from '../utils/elevation'
+
+const nativeRequire = createRequire(__filename)
+const prtScnHookName = 'prtscnhook.node'
+const forwardSent = 3
+
+let printScreenForwarding = false
+let printScreenHookInstalled = false
+let printScreenHookWindowHandle: bigint | null = null
+let prtScnHookAddon: PrtScnHookAddon | null | undefined
+let printScreenStatsTimer: ReturnType<typeof setInterval> | null = null
+let nativeForwardCount = 0
+let printScreenHookInstallFailureLogged = false
+let printScreenForwardFailureStatus: number | null = null
+
+type PrtScnHookAddon = {
+  installHook(windowHandle: bigint): boolean
+  uninstallHook(windowHandle: bigint): boolean
+  forwardPrtScn(windowHandle: bigint): number
+  canForwardPrtScn(windowHandle: bigint): boolean
+  getForwardCount(): number
+  getLastStatus(): number
+}
+
+function prtScnHookPath(): string {
+  return path.join(resourcesFilesDir(), prtScnHookName)
+}
+
+function getNativeWindowHandle(window: BrowserWindow): bigint | undefined {
+  const handle = window.getNativeWindowHandle()
+  if (handle.length < 4) return undefined
+
+  // Electron 在 64 位 Windows 下返回 8 字节 HWND, 保留 32 位分支以兼容 ia32 构建
+  const value = handle.length >= 8 ? handle.readBigUInt64LE(0) : BigInt(handle.readUInt32LE(0))
+
+  return value === 0n ? undefined : value
+}
+
+function isPlainPrintScreen(input: Electron.Input): boolean {
+  // 只处理裸 PrtScn; 带 Ctrl/Alt/Shift/Win 的组合键保持系统或其他软件原行为
+  return (
+    (input.type === 'keyDown' || input.type === 'keyUp') &&
+    (input.code === 'PrintScreen' || input.key === 'PrintScreen' || input.key === 'Printscreen') &&
+    !input.isAutoRepeat &&
+    !input.isComposing &&
+    !input.control &&
+    !input.alt &&
+    !input.shift &&
+    !input.meta
+  )
+}
+
+function loadPrtScnHookAddon(): PrtScnHookAddon | null {
+  if (prtScnHookAddon !== undefined) {
+    return prtScnHookAddon
+  }
+
+  try {
+    const addon = nativeRequire(prtScnHookPath()) as Partial<PrtScnHookAddon>
+    // addon 和 helper 都来自 resources/files
+    // 导出不完整时直接禁用
+    if (
+      typeof addon.installHook !== 'function' ||
+      typeof addon.uninstallHook !== 'function' ||
+      typeof addon.forwardPrtScn !== 'function' ||
+      typeof addon.canForwardPrtScn !== 'function' ||
+      typeof addon.getForwardCount !== 'function' ||
+      typeof addon.getLastStatus !== 'function'
+    ) {
+      void appendAppLog('[PrintScreen]: native hook addon exports are invalid\n')
+      prtScnHookAddon = null
+      return null
+    }
+
+    prtScnHookAddon = addon as PrtScnHookAddon
+    return prtScnHookAddon
+  } catch (error) {
+    void appendAppLog(`[PrintScreen]: native hook addon load failed, ${error}\n`)
+    prtScnHookAddon = null
+    return null
+  }
+}
+
+function forwardStatusText(status: number): string {
+  switch (status) {
+    case 0:
+      return 'helper=0'
+    case 1:
+      return 'launch=false'
+    case 2:
+      return 'helper=failed'
+    case forwardSent:
+      return 'sent=2'
+    case 4:
+      return 'post=false'
+    default:
+      return `status=${status}`
+  }
+}
+
+function logForwardFailure(status: number): void {
+  if (printScreenForwardFailureStatus === status) return
+
+  printScreenForwardFailureStatus = status
+  void appendAppLog(`[PrintScreen]: native forward skipped, ${forwardStatusText(status)}\n`)
+}
+
+function canForwardPrintScreen(window: BrowserWindow): boolean {
+  const addon = loadPrtScnHookAddon()
+  const windowHandle = getNativeWindowHandle(window)
+  if (!addon || !windowHandle) return false
+
+  try {
+    return addon.canForwardPrtScn(windowHandle)
+  } catch (error) {
+    void appendAppLog(`[PrintScreen]: native capability check failed, ${error}\n`)
+    return false
+  }
+}
+
+function installPrintScreenHook(window: BrowserWindow): void {
+  if (printScreenHookInstalled || window.isDestroyed()) return
+
+  const addon = loadPrtScnHookAddon()
+  const windowHandle = getNativeWindowHandle(window)
+  if (!addon || !windowHandle) return
+
+  try {
+    printScreenHookInstalled = addon.installHook(windowHandle)
+    printScreenHookWindowHandle = printScreenHookInstalled ? windowHandle : null
+    if (printScreenHookInstalled) {
+      printScreenHookInstallFailureLogged = false
+    }
+    if (!printScreenHookInstalled && !printScreenHookInstallFailureLogged) {
+      printScreenHookInstallFailureLogged = true
+      void appendAppLog('[PrintScreen]: native hook install failed\n')
+    }
+  } catch (error) {
+    printScreenHookInstalled = false
+    printScreenHookWindowHandle = null
+    if (!printScreenHookInstallFailureLogged) {
+      printScreenHookInstallFailureLogged = true
+      void appendAppLog(`[PrintScreen]: native hook install failed, ${error}\n`)
+    }
+  }
+}
+
+function uninstallPrintScreenHook(): void {
+  if (!printScreenHookInstalled) return
+
+  const addon = loadPrtScnHookAddon()
+  const windowHandle = printScreenHookWindowHandle
+  printScreenHookInstalled = false
+  printScreenHookWindowHandle = null
+  if (!addon || !windowHandle) return
+
+  try {
+    addon.uninstallHook(windowHandle)
+  } catch (error) {
+    void appendAppLog(`[PrintScreen]: native hook uninstall failed, ${error}\n`)
+  }
+}
+
+function stopPrintScreenStats(): void {
+  if (!printScreenStatsTimer) return
+
+  clearInterval(printScreenStatsTimer)
+  printScreenStatsTimer = null
+}
+
+function startPrintScreenStats(window: BrowserWindow): void {
+  if (printScreenStatsTimer) return
+
+  const addon = loadPrtScnHookAddon()
+  if (!addon) return
+
+  nativeForwardCount = addon.getForwardCount()
+  printScreenStatsTimer = setInterval(() => {
+    if (window.isDestroyed()) {
+      stopPrintScreenStats()
+      return
+    }
+
+    const currentCount = addon.getForwardCount()
+    if (currentCount === nativeForwardCount) return
+
+    nativeForwardCount = currentCount
+    const status = addon.getLastStatus()
+    if (status === forwardSent) {
+      printScreenForwardFailureStatus = null
+    } else {
+      logForwardFailure(status)
+    }
+  }, 1000)
+}
+
+function restoreForwardingState(window: BrowserWindow): void {
+  setTimeout(() => {
+    printScreenForwarding = false
+    if (window.isDestroyed()) return
+
+    // 转发会让 Sparkle 短暂失焦, 延迟后按当前焦点状态恢复 hook 生命周期
+    if (window.isFocused()) {
+      installPrintScreenHook(window)
+    } else {
+      uninstallPrintScreenHook()
+    }
+  }, 600)
+}
+
+function forwardPrintScreen(window: BrowserWindow): void {
+  if (printScreenForwarding || window.isDestroyed()) return
+
+  const addon = loadPrtScnHookAddon()
+  const windowHandle = getNativeWindowHandle(window)
+  if (!addon || !windowHandle) return
+
+  printScreenForwarding = true
+  try {
+    // Electron before-input-event 测试收不到到 PrtScn
+    // 但假设能收到时仍由 native helper 完成
+    const status = addon.forwardPrtScn(windowHandle)
+    if (status === forwardSent) {
+      printScreenForwardFailureStatus = null
+    } else {
+      logForwardFailure(status)
+    }
+  } catch (error) {
+    void appendAppLog(`[PrintScreen]: native forward failed, ${error}\n`)
+  } finally {
+    restoreForwardingState(window)
+  }
+}
+
+function installPrintScreenHookLifecycle(window: BrowserWindow): void {
+  // hook 只在 Sparkle 窗口前台时安装, 避免用户切到其他应用后仍拦截全局 PrtScn
+  window.on('focus', () => {
+    if (!printScreenForwarding) installPrintScreenHook(window)
+  })
+
+  window.on('blur', () => {
+    if (!printScreenForwarding) uninstallPrintScreenHook()
+  })
+
+  window.on('close', () => {
+    stopPrintScreenStats()
+    uninstallPrintScreenHook()
+  })
+}
+
+export function installPrintScreenCompatibility(window: BrowserWindow): void {
+  if (process.platform !== 'win32') return
+
+  void getAppConfig()
+    .then(async ({ disablePrintScreenCompatibility = false }) => {
+      if (disablePrintScreenCompatibility || window.isDestroyed()) return
+
+      // 普通权限窗口不会触发该兼容问题; 只在管理员运行时启用 native hook
+      const isAdmin = await isRunningAsAdmin()
+      if (!isAdmin || window.isDestroyed()) return
+
+      if (!canForwardPrintScreen(window)) return
+
+      installPrintScreenHookLifecycle(window)
+      if (window.isFocused()) installPrintScreenHook(window)
+      startPrintScreenStats(window)
+
+      window.webContents.on('before-input-event', (event, input) => {
+        if (!isPlainPrintScreen(input)) return
+
+        event.preventDefault()
+        if (input.type === 'keyDown') {
+          forwardPrintScreen(window)
+        }
+      })
+    })
+    .catch((error) => {
+      void appendAppLog(`[PrintScreen]: compatibility init failed, ${error}\n`)
+    })
+}

--- a/src/main/sys/win32/prtscnhelper.cpp
+++ b/src/main/sys/win32/prtscnhelper.cpp
@@ -1,0 +1,269 @@
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+namespace {
+
+// 启动普通权限的几乎不可见前台窗口, 用于让系统 PrtScn 映射正确
+
+constexpr UINT kInputCount = 2;
+constexpr int kFocusAttempts = 5;
+constexpr DWORD kFocusDelayMs = 80;
+constexpr DWORD kWindowLifetimeMs = 250;
+constexpr int kForwardWindowSize = 1;
+constexpr BYTE kForwardWindowAlpha = 1;
+constexpr wchar_t kForwardWindowClassName[] = L"SparklePrtScnMediumWindow";
+
+constexpr DWORD kExitOk = 0;
+constexpr DWORD kExitTokenInvalid = 2;
+constexpr DWORD kExitWindowCreateFailed = 3;
+constexpr DWORD kExitFocusFailed = 4;
+constexpr DWORD kExitSendFailed = 5;
+
+void ClearMemory(void* buffer, SIZE_T size) {
+  // no-CRT 构建下工具函数
+  auto* bytes = static_cast<volatile unsigned char*>(buffer);
+  for (SIZE_T i = 0; i < size; i++) {
+    bytes[i] = 0;
+  }
+}
+
+bool IsSpace(wchar_t value) {
+  return value == L' ' || value == L'\t';
+}
+
+bool StartsWith(const wchar_t* value, const wchar_t* prefix) {
+  while (*prefix != L'\0') {
+    if (*value != *prefix) {
+      return false;
+    }
+    value++;
+    prefix++;
+  }
+
+  return true;
+}
+
+const wchar_t* FindArgValue(const wchar_t* commandLine, const wchar_t* name) {
+  for (const wchar_t* current = commandLine; *current != L'\0'; current++) {
+    if (current != commandLine && !IsSpace(*(current - 1))) {
+      continue;
+    }
+
+    if (!StartsWith(current, name)) {
+      continue;
+    }
+
+    current += lstrlenW(name);
+    if (!IsSpace(*current)) {
+      continue;
+    }
+
+    while (IsSpace(*current)) {
+      current++;
+    }
+    return current;
+  }
+
+  return nullptr;
+}
+
+bool ParseLongArg(const wchar_t* commandLine, const wchar_t* name, LONG* value) {
+  const wchar_t* current = FindArgValue(commandLine, name);
+  if (current == nullptr) {
+    return false;
+  }
+
+  bool negative = false;
+  if (*current == L'-') {
+    negative = true;
+    current++;
+  }
+
+  LONG parsed = 0;
+  bool hasDigit = false;
+  while (*current >= L'0' && *current <= L'9') {
+    parsed = parsed * 10 + (*current - L'0');
+    hasDigit = true;
+    current++;
+  }
+
+  if (!hasDigit) {
+    return false;
+  }
+
+  *value = negative ? -parsed : parsed;
+  return true;
+}
+
+bool GetTokenElevationFlag(HANDLE token, DWORD* elevated) {
+  TOKEN_ELEVATION elevation;
+  DWORD returned = 0;
+  if (!GetTokenInformation(token, TokenElevation, &elevation, sizeof(elevation), &returned)) {
+    return false;
+  }
+
+  *elevated = elevation.TokenIsElevated;
+  return true;
+}
+
+bool GetTokenIntegrityRid(HANDLE token, DWORD* rid) {
+  DWORD length = 0;
+  GetTokenInformation(token, TokenIntegrityLevel, nullptr, 0, &length);
+  if (GetLastError() != ERROR_INSUFFICIENT_BUFFER || length == 0) {
+    return false;
+  }
+
+  BYTE* buffer = static_cast<BYTE*>(HeapAlloc(GetProcessHeap(), 0, length));
+  if (buffer == nullptr) {
+    return false;
+  }
+
+  bool ok = false;
+  if (GetTokenInformation(token, TokenIntegrityLevel, buffer, length, &length)) {
+    auto* label = reinterpret_cast<TOKEN_MANDATORY_LABEL*>(buffer);
+    DWORD subAuthorityCount = *GetSidSubAuthorityCount(label->Label.Sid);
+    *rid = *GetSidSubAuthority(label->Label.Sid, subAuthorityCount - 1);
+    ok = true;
+  }
+
+  HeapFree(GetProcessHeap(), 0, buffer);
+  return ok;
+}
+
+bool IsCurrentProcessMediumNonElevated() {
+  // helper 若被错误地以管理员权限运行, 直接退出, 避免回到原始问题
+  HANDLE token = nullptr;
+  if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token)) {
+    return false;
+  }
+
+  DWORD elevated = 1;
+  DWORD integrityRid = 0;
+  const bool ok = GetTokenElevationFlag(token, &elevated) && elevated == 0 &&
+                  GetTokenIntegrityRid(token, &integrityRid) &&
+                  integrityRid == SECURITY_MANDATORY_MEDIUM_RID;
+  CloseHandle(token);
+  return ok;
+}
+
+LRESULT CALLBACK ForwardWindowProc(HWND window, UINT message, WPARAM wParam, LPARAM lParam) {
+  if (message == WM_ERASEBKGND) {
+    return 1;
+  }
+
+  if (message == WM_PAINT) {
+    PAINTSTRUCT paint;
+    BeginPaint(window, &paint);
+    EndPaint(window, &paint);
+    return 0;
+  }
+
+  return DefWindowProcW(window, message, wParam, lParam);
+}
+
+bool RegisterForwardWindowClass() {
+  WNDCLASSEXW windowClass;
+  ClearMemory(&windowClass, sizeof(windowClass));
+  windowClass.cbSize = sizeof(windowClass);
+  windowClass.lpfnWndProc = ForwardWindowProc;
+  windowClass.hInstance = GetModuleHandleW(nullptr);
+  windowClass.lpszClassName = kForwardWindowClassName;
+
+  ATOM atom = RegisterClassExW(&windowClass);
+  return atom != 0 || GetLastError() == ERROR_CLASS_ALREADY_EXISTS;
+}
+
+HWND CreateForwardWindow(LONG x, LONG y) {
+  if (!RegisterForwardWindowClass()) {
+    return nullptr;
+  }
+
+  // 近透明窗口必须可激活为前台窗口; 不要使用 WS_EX_NOACTIVATE
+  HWND window = CreateWindowExW(
+    WS_EX_TOOLWINDOW | WS_EX_LAYERED | WS_EX_TOPMOST,
+    kForwardWindowClassName,
+    L"",
+    WS_POPUP,
+    x,
+    y,
+    kForwardWindowSize,
+    kForwardWindowSize,
+    nullptr,
+    nullptr,
+    GetModuleHandleW(nullptr),
+    nullptr
+  );
+  if (window == nullptr) {
+    return nullptr;
+  }
+
+  SetLayeredWindowAttributes(window, 0, kForwardWindowAlpha, LWA_ALPHA);
+  ShowWindow(window, SW_SHOW);
+  UpdateWindow(window);
+  return window;
+}
+
+bool FocusForwardWindow(HWND window) {
+  for (int i = 0; i < kFocusAttempts; i++) {
+    SetForegroundWindow(window);
+    if (GetForegroundWindow() == window) {
+      return true;
+    }
+
+    if (i + 1 < kFocusAttempts) {
+      Sleep(kFocusDelayMs);
+    }
+  }
+
+  return false;
+}
+
+UINT SendPrintScreen() {
+  INPUT inputs[kInputCount];
+  ClearMemory(inputs, sizeof(inputs));
+
+  inputs[0].type = INPUT_KEYBOARD;
+  inputs[0].ki.wVk = VK_SNAPSHOT;
+
+  inputs[1].type = INPUT_KEYBOARD;
+  inputs[1].ki.wVk = VK_SNAPSHOT;
+  inputs[1].ki.dwFlags = KEYEVENTF_KEYUP;
+
+  return SendInput(kInputCount, inputs, sizeof(INPUT));
+}
+
+DWORD RunHelper() {
+  if (!IsCurrentProcessMediumNonElevated()) {
+    return kExitTokenInvalid;
+  }
+
+  LONG x = 0;
+  LONG y = 0;
+  const wchar_t* commandLine = GetCommandLineW();
+  ParseLongArg(commandLine, L"--x", &x);
+  ParseLongArg(commandLine, L"--y", &y);
+
+  HWND window = CreateForwardWindow(x, y);
+  if (window == nullptr) {
+    return kExitWindowCreateFailed;
+  }
+
+  if (!FocusForwardWindow(window)) {
+    DestroyWindow(window);
+    return kExitFocusFailed;
+  }
+
+  // 此时前台窗口是普通权限 helper, PrtScn 绕过 UIPI 限制
+  const UINT sent = SendPrintScreen();
+  // SendInput 只是入队输入事件; 短暂保留窗口, 避免系统尚未处理时焦点回到 Sparkle
+  Sleep(kWindowLifetimeMs);
+  DestroyWindow(window);
+
+  return sent == kInputCount ? kExitOk : kExitSendFailed;
+}
+
+}
+
+extern "C" void __stdcall wWinMainCRTStartup() {
+  ExitProcess(RunHelper());
+}

--- a/src/main/sys/win32/prtscnhook.cpp
+++ b/src/main/sys/win32/prtscnhook.cpp
@@ -1,0 +1,1086 @@
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <tlhelp32.h>
+
+namespace {
+
+// 在高权限 Sparkle 前台时, Windows 的裸 PrtScn 映射可能退回旧式全屏截图
+// 这里捕获物理裸 PrtScn, 并通过普通权限 helper 重新触发系统截图路径
+
+constexpr UINT kForwardMessage = WM_APP + 0x522c;
+constexpr DWORD kForwardHelperTimeoutMs = 3000;
+
+constexpr UINT kForwardNoTarget = 0;
+constexpr UINT kForwardFocusFailed = 1;
+constexpr UINT kForwardSendFailed = 2;
+constexpr UINT kForwardSent = 3;
+constexpr UINT kForwardPostFailed = 4;
+constexpr DWORD kHookThreadStartupTimeoutMs = 3000;
+constexpr DWORD kHookThreadShutdownTimeoutMs = 3000;
+constexpr int kHookThreadPriority = THREAD_PRIORITY_HIGHEST;
+
+constexpr wchar_t kPrtScnHelperFileName[] = L"prtscnhelper.exe";
+
+// 此 addon 只动态解析需要的 N-API
+using napi_env = void*;
+using napi_value = void*;
+using napi_callback_info = void*;
+using napi_status = int;
+using napi_callback = napi_value(__cdecl*)(napi_env env, napi_callback_info info);
+
+using NapiGetCbInfo = napi_status(__cdecl*)(
+  napi_env env,
+  napi_callback_info info,
+  size_t* argc,
+  napi_value* argv,
+  napi_value* thisArg,
+  void** data
+);
+using NapiGetBigIntUint64 = napi_status(__cdecl*)(
+  napi_env env,
+  napi_value value,
+  unsigned __int64* result,
+  bool* lossless
+);
+using NapiGetBoolean = napi_status(__cdecl*)(napi_env env, bool value, napi_value* result);
+using NapiCreateUint32 = napi_status(__cdecl*)(
+  napi_env env,
+  unsigned int value,
+  napi_value* result
+);
+using NapiCreateFunction = napi_status(__cdecl*)(
+  napi_env env,
+  const char* utf8Name,
+  size_t length,
+  napi_callback cb,
+  void* data,
+  napi_value* result
+);
+using NapiSetNamedProperty = napi_status(__cdecl*)(
+  napi_env env,
+  napi_value object,
+  const char* utf8Name,
+  napi_value value
+);
+using NapiThrowError = napi_status(__cdecl*)(
+  napi_env env,
+  const char* code,
+  const char* message
+);
+using NapiGetUndefined = napi_status(__cdecl*)(napi_env env, napi_value* result);
+
+struct HookState {
+  HWND window;
+  WNDPROC previousWndProc;
+  HHOOK keyboardHook;
+  HANDLE hookThread;
+  DWORD hookThreadId;
+  HANDLE hookReadyEvent;
+  bool hookReady;
+  bool hookInstalled;
+  bool forwarding;
+  bool suppressKeyUp;
+  UINT forwardCount;
+  UINT lastStatus;
+};
+
+struct NapiApi {
+  bool resolved;
+  bool ok;
+  NapiGetCbInfo getCbInfo;
+  NapiGetBigIntUint64 getBigIntUint64;
+  NapiGetBoolean getBoolean;
+  NapiCreateUint32 createUint32;
+  NapiCreateFunction createFunction;
+  NapiSetNamedProperty setNamedProperty;
+  NapiThrowError throwError;
+  NapiGetUndefined getUndefined;
+};
+
+struct ForwardResult {
+  bool targetFound;
+  bool launched;
+  DWORD exitCode;
+};
+
+NapiApi g_napi = {};
+HookState g_hookState = {};
+
+SRWLOCK g_hookLock = SRWLOCK_INIT;
+
+LRESULT CALLBACK PrintScreenHookProc(int code, WPARAM wParam, LPARAM lParam);
+LRESULT CALLBACK HookWndProc(HWND window, UINT message, WPARAM wParam, LPARAM lParam);
+DWORD WINAPI HookThreadProc(void*);
+DWORD WINAPI ForwardThreadProc(void* param);
+HMODULE GetCurrentModule();
+
+FARPROC FindHostSymbol(const char* name) {
+  HMODULE modules[] = {
+    GetModuleHandleW(nullptr),
+    GetModuleHandleW(L"electron.exe"),
+    GetModuleHandleW(L"node.exe"),
+    GetModuleHandleW(L"node.dll"),
+  };
+
+  for (int i = 0; i < static_cast<int>(sizeof(modules) / sizeof(modules[0])); i++) {
+    if (modules[i] == nullptr) {
+      continue;
+    }
+
+    FARPROC symbol = GetProcAddress(modules[i], name);
+    if (symbol != nullptr) {
+      return symbol;
+    }
+  }
+
+  return nullptr;
+}
+
+template <typename T>
+bool ResolveNapiSymbol(T* target, const char* name) {
+  FARPROC symbol = FindHostSymbol(name);
+  if (symbol == nullptr) {
+    return false;
+  }
+
+  *target = reinterpret_cast<T>(symbol);
+  return true;
+}
+
+bool ResolveNapi() {
+  if (g_napi.resolved) {
+    return g_napi.ok;
+  }
+
+  g_napi.resolved = true;
+  g_napi.ok =
+    ResolveNapiSymbol(&g_napi.getCbInfo, "napi_get_cb_info") &&
+    ResolveNapiSymbol(&g_napi.getBigIntUint64, "napi_get_value_bigint_uint64") &&
+    ResolveNapiSymbol(&g_napi.getBoolean, "napi_get_boolean") &&
+    ResolveNapiSymbol(&g_napi.createUint32, "napi_create_uint32") &&
+    ResolveNapiSymbol(&g_napi.createFunction, "napi_create_function") &&
+    ResolveNapiSymbol(&g_napi.setNamedProperty, "napi_set_named_property") &&
+    ResolveNapiSymbol(&g_napi.throwError, "napi_throw_error") &&
+    ResolveNapiSymbol(&g_napi.getUndefined, "napi_get_undefined");
+
+  return g_napi.ok;
+}
+
+napi_value Undefined(napi_env env) {
+  napi_value result = nullptr;
+  if (ResolveNapi()) {
+    g_napi.getUndefined(env, &result);
+  }
+  return result;
+}
+
+napi_value ThrowError(napi_env env, const char* message) {
+  if (ResolveNapi()) {
+    g_napi.throwError(env, nullptr, message);
+  }
+  return Undefined(env);
+}
+
+bool GetWindowArg(napi_env env, napi_callback_info info, HWND* window) {
+  napi_value args[1] = {};
+  size_t argc = 1;
+  if (g_napi.getCbInfo(env, info, &argc, args, nullptr, nullptr) != 0 || argc < 1) {
+    return false;
+  }
+
+  unsigned __int64 windowValue = 0;
+  bool lossless = false;
+  if (g_napi.getBigIntUint64(env, args[0], &windowValue, &lossless) != 0 || !lossless ||
+      windowValue == 0) {
+    return false;
+  }
+
+  *window = reinterpret_cast<HWND>(static_cast<ULONG_PTR>(windowValue));
+  return true;
+}
+
+napi_value BooleanValue(napi_env env, bool value) {
+  napi_value result = nullptr;
+  g_napi.getBoolean(env, value, &result);
+  return result;
+}
+
+napi_value Uint32Value(napi_env env, UINT value) {
+  napi_value result = nullptr;
+  g_napi.createUint32(env, value, &result);
+  return result;
+}
+
+void ClearMemory(void* buffer, SIZE_T size) {
+  // no-CRT 构建下工具函数
+  auto* bytes = static_cast<volatile unsigned char*>(buffer);
+  for (SIZE_T i = 0; i < size; i++) {
+    bytes[i] = 0;
+  }
+}
+
+bool CopyString(wchar_t* target, DWORD targetLength, const wchar_t* source) {
+  if (targetLength == 0) {
+    return false;
+  }
+
+  DWORD index = 0;
+  while (source[index] != L'\0') {
+    if (index + 1 >= targetLength) {
+      target[0] = L'\0';
+      return false;
+    }
+    target[index] = source[index];
+    index++;
+  }
+
+  target[index] = L'\0';
+  return true;
+}
+
+bool AppendString(wchar_t* target, DWORD targetLength, DWORD* offset, const wchar_t* source) {
+  while (*source != L'\0') {
+    if (*offset + 1 >= targetLength) {
+      return false;
+    }
+    target[*offset] = *source;
+    (*offset)++;
+    source++;
+  }
+  target[*offset] = L'\0';
+  return true;
+}
+
+bool AppendLong(wchar_t* target, DWORD targetLength, DWORD* offset, LONG value) {
+  wchar_t buffer[16];
+  DWORD bufferOffset = 0;
+  LONG remaining = value;
+  bool negative = false;
+
+  if (remaining < 0) {
+    negative = true;
+    remaining = -remaining;
+  }
+
+  do {
+    if (bufferOffset >= static_cast<DWORD>(sizeof(buffer) / sizeof(buffer[0]))) {
+      return false;
+    }
+    buffer[bufferOffset] = static_cast<wchar_t>(L'0' + (remaining % 10));
+    remaining /= 10;
+    bufferOffset++;
+  } while (remaining > 0);
+
+  if (negative && !AppendString(target, targetLength, offset, L"-")) {
+    return false;
+  }
+
+  while (bufferOffset > 0) {
+    bufferOffset--;
+    if (*offset + 1 >= targetLength) {
+      return false;
+    }
+    target[*offset] = buffer[bufferOffset];
+    (*offset)++;
+  }
+  target[*offset] = L'\0';
+  return true;
+}
+
+bool BuildHelperCommandLine(
+  const wchar_t* helperPath,
+  LONG x,
+  LONG y,
+  wchar_t* commandLine,
+  DWORD commandLineLength
+) {
+  DWORD offset = 0;
+  commandLine[0] = L'\0';
+  return AppendString(commandLine, commandLineLength, &offset, L"\"") &&
+         AppendString(commandLine, commandLineLength, &offset, helperPath) &&
+         AppendString(commandLine, commandLineLength, &offset, L"\" --x ") &&
+         AppendLong(commandLine, commandLineLength, &offset, x) &&
+         AppendString(commandLine, commandLineLength, &offset, L" --y ") &&
+         AppendLong(commandLine, commandLineLength, &offset, y);
+}
+
+bool GetCurrentSessionId(DWORD* sessionId) {
+  return ProcessIdToSessionId(GetCurrentProcessId(), sessionId) != FALSE;
+}
+
+bool GetTokenElevationFlag(HANDLE token, DWORD* elevated) {
+  TOKEN_ELEVATION elevation;
+  DWORD returned = 0;
+  if (!GetTokenInformation(token, TokenElevation, &elevation, sizeof(elevation), &returned)) {
+    return false;
+  }
+
+  *elevated = elevation.TokenIsElevated;
+  return true;
+}
+
+bool GetTokenIntegrityRid(HANDLE token, DWORD* rid) {
+  DWORD length = 0;
+  GetTokenInformation(token, TokenIntegrityLevel, nullptr, 0, &length);
+  if (GetLastError() != ERROR_INSUFFICIENT_BUFFER || length == 0) {
+    return false;
+  }
+
+  BYTE* buffer = static_cast<BYTE*>(HeapAlloc(GetProcessHeap(), 0, length));
+  if (buffer == nullptr) {
+    return false;
+  }
+
+  bool ok = false;
+  if (GetTokenInformation(token, TokenIntegrityLevel, buffer, length, &length)) {
+    auto* label = reinterpret_cast<TOKEN_MANDATORY_LABEL*>(buffer);
+    DWORD subAuthorityCount = *GetSidSubAuthorityCount(label->Label.Sid);
+    *rid = *GetSidSubAuthority(label->Label.Sid, subAuthorityCount - 1);
+    ok = true;
+  }
+
+  HeapFree(GetProcessHeap(), 0, buffer);
+  return ok;
+}
+
+bool IsMediumNonElevatedToken(HANDLE token) {
+  DWORD elevated = 1;
+  DWORD integrityRid = 0;
+
+  return GetTokenElevationFlag(token, &elevated) && elevated == 0 &&
+         GetTokenIntegrityRid(token, &integrityRid) &&
+         integrityRid == SECURITY_MANDATORY_MEDIUM_RID;
+}
+
+bool OpenExplorerToken(HANDLE* explorerToken) {
+  DWORD currentSessionId = 0;
+  if (!GetCurrentSessionId(&currentSessionId)) {
+    return false;
+  }
+
+  // 复制当前 session 的普通权限 Explorer token; 未对 Explorer 做有副作用的操作
+  HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+  if (snapshot == INVALID_HANDLE_VALUE) {
+    return false;
+  }
+
+  PROCESSENTRY32W entry;
+  ClearMemory(&entry, sizeof(entry));
+  entry.dwSize = sizeof(entry);
+  bool found = false;
+
+  if (Process32FirstW(snapshot, &entry)) {
+    do {
+      if (lstrcmpiW(entry.szExeFile, L"explorer.exe") != 0) {
+        continue;
+      }
+
+      DWORD processSessionId = 0;
+      if (!ProcessIdToSessionId(entry.th32ProcessID, &processSessionId) ||
+          processSessionId != currentSessionId) {
+        continue;
+      }
+
+      HANDLE process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, entry.th32ProcessID);
+      if (process == nullptr) {
+        continue;
+      }
+
+      HANDLE token = nullptr;
+      const BOOL opened = OpenProcessToken(
+        process,
+        TOKEN_QUERY | TOKEN_DUPLICATE | TOKEN_ASSIGN_PRIMARY | TOKEN_ADJUST_DEFAULT |
+          TOKEN_ADJUST_SESSIONID,
+        &token
+      );
+      CloseHandle(process);
+      if (!opened) {
+        continue;
+      }
+
+      if (!IsMediumNonElevatedToken(token)) {
+        CloseHandle(token);
+        continue;
+      }
+
+      *explorerToken = token;
+      found = true;
+      break;
+    } while (Process32NextW(snapshot, &entry));
+  }
+
+  CloseHandle(snapshot);
+  return found;
+}
+
+bool DuplicatePrimaryToken(HANDLE token, HANDLE* primaryToken) {
+  return DuplicateTokenEx(
+           token,
+           TOKEN_ASSIGN_PRIMARY | TOKEN_DUPLICATE | TOKEN_QUERY | TOKEN_ADJUST_DEFAULT |
+             TOKEN_ADJUST_SESSIONID,
+           nullptr,
+           SecurityImpersonation,
+           TokenPrimary,
+           primaryToken
+         ) != FALSE;
+}
+
+bool GetPrtScnHelperPath(wchar_t* helperPath, DWORD helperPathLength) {
+  HMODULE module = GetCurrentModule();
+  if (module == nullptr ||
+      GetModuleFileNameW(module, helperPath, helperPathLength) == 0) {
+    return false;
+  }
+
+  // helper 与 addon 同目录, 避免从 PATH 或外部输入解析可执行文件
+  wchar_t* fileName = helperPath;
+  for (wchar_t* current = helperPath; *current != L'\0'; current++) {
+    if (*current == L'\\' || *current == L'/') {
+      fileName = current + 1;
+    }
+  }
+
+  return CopyString(fileName, static_cast<DWORD>(helperPath + helperPathLength - fileName), kPrtScnHelperFileName);
+}
+
+bool GetForwardPoint(HWND sourceWindow, LONG* x, LONG* y) {
+  // helper 窗口放在 Sparkle 所在显示器, 避免多屏环境下焦点跳到其他屏
+  HMONITOR monitor = MonitorFromWindow(sourceWindow, MONITOR_DEFAULTTONEAREST);
+  if (monitor == nullptr) {
+    return false;
+  }
+
+  MONITORINFO monitorInfo;
+  ClearMemory(&monitorInfo, sizeof(monitorInfo));
+  monitorInfo.cbSize = sizeof(monitorInfo);
+  if (!GetMonitorInfoW(monitor, &monitorInfo)) {
+    return false;
+  }
+
+  *x = monitorInfo.rcMonitor.left;
+  *y = monitorInfo.rcMonitor.top;
+  return true;
+}
+
+bool LaunchPrtScnHelper(
+  HANDLE token,
+  const wchar_t* helperPath,
+  wchar_t* commandLine,
+  PROCESS_INFORMATION* processInfo
+) {
+  STARTUPINFOW startupInfo;
+  ClearMemory(&startupInfo, sizeof(startupInfo));
+  startupInfo.cb = sizeof(startupInfo);
+  startupInfo.lpDesktop = const_cast<wchar_t*>(L"winsta0\\default");
+  ClearMemory(processInfo, sizeof(*processInfo));
+
+  // 挂起启动后先允许 helper 设前台, 再恢复执行
+  if (!CreateProcessWithTokenW(
+        token,
+        0,
+        helperPath,
+        commandLine,
+        CREATE_NO_WINDOW | CREATE_SUSPENDED,
+        nullptr,
+        nullptr,
+        &startupInfo,
+        processInfo
+      )) {
+    return false;
+  }
+
+  AllowSetForegroundWindow(processInfo->dwProcessId);
+  if (ResumeThread(processInfo->hThread) == static_cast<DWORD>(-1)) {
+    TerminateProcess(processInfo->hProcess, 1);
+    CloseHandle(processInfo->hThread);
+    CloseHandle(processInfo->hProcess);
+    ClearMemory(processInfo, sizeof(*processInfo));
+    return false;
+  }
+
+  return true;
+}
+
+ForwardResult ForwardPrintScreen(HWND sourceWindow) {
+  ForwardResult result = { false, false, 1 };
+  if (sourceWindow == nullptr || !IsWindow(sourceWindow)) {
+    return result;
+  }
+
+  wchar_t helperPath[MAX_PATH];
+  if (!GetPrtScnHelperPath(helperPath, MAX_PATH) ||
+      GetFileAttributesW(helperPath) == INVALID_FILE_ATTRIBUTES) {
+    return result;
+  }
+
+  LONG x = 0;
+  LONG y = 0;
+  if (!GetForwardPoint(sourceWindow, &x, &y)) {
+    return result;
+  }
+
+  HANDLE explorerToken = nullptr;
+  if (!OpenExplorerToken(&explorerToken)) {
+    return result;
+  }
+
+  HANDLE primaryToken = nullptr;
+  if (!DuplicatePrimaryToken(explorerToken, &primaryToken)) {
+    CloseHandle(explorerToken);
+    return result;
+  }
+
+  result.targetFound = true;
+
+  wchar_t commandLine[1024];
+  if (!BuildHelperCommandLine(helperPath, x, y, commandLine, 1024)) {
+    CloseHandle(primaryToken);
+    CloseHandle(explorerToken);
+    return result;
+  }
+
+  PROCESS_INFORMATION processInfo;
+  if (!LaunchPrtScnHelper(primaryToken, helperPath, commandLine, &processInfo)) {
+    CloseHandle(primaryToken);
+    CloseHandle(explorerToken);
+    return result;
+  }
+
+  result.launched = true;
+  const DWORD waitResult = WaitForSingleObject(processInfo.hProcess, kForwardHelperTimeoutMs);
+  if (waitResult == WAIT_OBJECT_0) {
+    DWORD exitCode = 1;
+    if (GetExitCodeProcess(processInfo.hProcess, &exitCode)) {
+      result.exitCode = exitCode;
+    }
+  }
+
+  CloseHandle(processInfo.hThread);
+  CloseHandle(processInfo.hProcess);
+  CloseHandle(primaryToken);
+  CloseHandle(explorerToken);
+  return result;
+}
+
+bool CanForwardPrintScreen(HWND sourceWindow) {
+  // 没有可用普通权限 token 时, 不安装 hook, 保持系统 PrtScn 原行为
+  // UAC "从不通知" 通常仍会保留 Medium Explorer token, 此时检查会通过
+  // 若 Admin Approval Mode 被策略禁用, 内置 Administrator 直接使用 full token
+  // 或 Explorer 被异常提权, 则检查失败
+  if (sourceWindow == nullptr || !IsWindow(sourceWindow)) {
+    return false;
+  }
+
+  wchar_t helperPath[MAX_PATH];
+  if (!GetPrtScnHelperPath(helperPath, MAX_PATH) ||
+      GetFileAttributesW(helperPath) == INVALID_FILE_ATTRIBUTES) {
+    return false;
+  }
+
+  LONG x = 0;
+  LONG y = 0;
+  if (!GetForwardPoint(sourceWindow, &x, &y)) {
+    return false;
+  }
+
+  HANDLE explorerToken = nullptr;
+  if (!OpenExplorerToken(&explorerToken)) {
+    return false;
+  }
+
+  HANDLE primaryToken = nullptr;
+  const bool ok = DuplicatePrimaryToken(explorerToken, &primaryToken);
+  if (primaryToken != nullptr) {
+    CloseHandle(primaryToken);
+  }
+  CloseHandle(explorerToken);
+  return ok;
+}
+
+UINT ToForwardStatus(const ForwardResult& result) {
+  if (!result.targetFound) {
+    return kForwardNoTarget;
+  }
+  if (!result.launched) {
+    return kForwardFocusFailed;
+  }
+  if (result.exitCode != 0) {
+    return kForwardSendFailed;
+  }
+  return kForwardSent;
+}
+
+void FinishForwardStatus(UINT status) {
+  AcquireSRWLockExclusive(&g_hookLock);
+  g_hookState.lastStatus = status;
+  g_hookState.forwardCount++;
+  g_hookState.forwarding = false;
+  ReleaseSRWLockExclusive(&g_hookLock);
+}
+
+void RestoreWindowProc(HWND window, WNDPROC previousWndProc) {
+  if (window != nullptr && previousWndProc != nullptr && IsWindow(window)) {
+    SetWindowLongPtrW(window, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(previousWndProc));
+  }
+}
+
+void RestoreWindowProc() {
+  RestoreWindowProc(g_hookState.window, g_hookState.previousWndProc);
+}
+
+void ClearHookState() {
+  g_hookState.window = nullptr;
+  g_hookState.previousWndProc = nullptr;
+  g_hookState.keyboardHook = nullptr;
+  g_hookState.hookThread = nullptr;
+  g_hookState.hookThreadId = 0;
+  g_hookState.hookReadyEvent = nullptr;
+  g_hookState.hookReady = false;
+  g_hookState.hookInstalled = false;
+  g_hookState.forwarding = false;
+  g_hookState.suppressKeyUp = false;
+}
+
+void StopHookThread() {
+  HANDLE hookThread = nullptr;
+  DWORD hookThreadId = 0;
+  HHOOK keyboardHook = nullptr;
+
+  AcquireSRWLockExclusive(&g_hookLock);
+  hookThread = g_hookState.hookThread;
+  hookThreadId = g_hookState.hookThreadId;
+  keyboardHook = g_hookState.keyboardHook;
+  g_hookState.hookThread = nullptr;
+  g_hookState.hookThreadId = 0;
+  ReleaseSRWLockExclusive(&g_hookLock);
+
+  if (hookThread == nullptr) {
+    return;
+  }
+
+  if (hookThreadId != 0) {
+    PostThreadMessageW(hookThreadId, WM_QUIT, 0, 0);
+  }
+
+  DWORD waitResult = WaitForSingleObject(hookThread, kHookThreadShutdownTimeoutMs);
+  if (waitResult != WAIT_OBJECT_0 && keyboardHook != nullptr) {
+    // 避免异常退出时残留全局 hook
+    UnhookWindowsHookEx(keyboardHook);
+    WaitForSingleObject(hookThread, kHookThreadShutdownTimeoutMs);
+  }
+  CloseHandle(hookThread);
+}
+
+void UninstallHookState() {
+  HWND window = nullptr;
+  WNDPROC previousWndProc = nullptr;
+
+  StopHookThread();
+
+  AcquireSRWLockExclusive(&g_hookLock);
+  window = g_hookState.window;
+  previousWndProc = g_hookState.previousWndProc;
+  ClearHookState();
+  ReleaseSRWLockExclusive(&g_hookLock);
+
+  RestoreWindowProc(window, previousWndProc);
+}
+
+bool IsSourceForeground() {
+  HWND source = nullptr;
+  AcquireSRWLockShared(&g_hookLock);
+  source = g_hookState.window;
+  ReleaseSRWLockShared(&g_hookLock);
+
+  HWND foreground = GetForegroundWindow();
+  if (source == nullptr || foreground == nullptr || !IsWindow(source)) {
+    return false;
+  }
+
+  if (foreground == source || IsChild(source, foreground)) {
+    return true;
+  }
+
+  return GetAncestor(foreground, GA_ROOT) == source;
+}
+
+bool IsPlainModifierState() {
+  const int modifiers[] = {
+    VK_CONTROL,
+    VK_LCONTROL,
+    VK_RCONTROL,
+    VK_MENU,
+    VK_LMENU,
+    VK_RMENU,
+    VK_SHIFT,
+    VK_LSHIFT,
+    VK_RSHIFT,
+    VK_LWIN,
+    VK_RWIN,
+  };
+
+  for (int i = 0; i < static_cast<int>(sizeof(modifiers) / sizeof(modifiers[0])); i++) {
+    if ((GetAsyncKeyState(modifiers[i]) & 0x8000) != 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void ForwardFromWindowProc() {
+  HWND window = nullptr;
+  AcquireSRWLockShared(&g_hookLock);
+  window = g_hookState.window;
+  ReleaseSRWLockShared(&g_hookLock);
+
+  if (window == nullptr || !IsWindow(window)) {
+    FinishForwardStatus(kForwardNoTarget);
+    return;
+  }
+
+  // 避免阻塞 Electron
+  HANDLE thread = CreateThread(
+    nullptr,
+    0,
+    ForwardThreadProc,
+    reinterpret_cast<void*>(window),
+    0,
+    nullptr
+  );
+  if (thread == nullptr) {
+    FinishForwardStatus(kForwardFocusFailed);
+    return;
+  }
+
+  CloseHandle(thread);
+}
+
+LRESULT CallPreviousWindowProc(HWND window, UINT message, WPARAM wParam, LPARAM lParam) {
+  WNDPROC previousWndProc = nullptr;
+  AcquireSRWLockShared(&g_hookLock);
+  previousWndProc = g_hookState.previousWndProc;
+  ReleaseSRWLockShared(&g_hookLock);
+
+  if (previousWndProc == nullptr) {
+    return DefWindowProcW(window, message, wParam, lParam);
+  }
+
+  return CallWindowProcW(previousWndProc, window, message, wParam, lParam);
+}
+
+LRESULT CALLBACK HookWndProc(HWND window, UINT message, WPARAM wParam, LPARAM lParam) {
+  if (message == kForwardMessage) {
+    ForwardFromWindowProc();
+    return 0;
+  }
+
+  if (message == WM_NCDESTROY) {
+    WNDPROC previousWndProc = nullptr;
+    AcquireSRWLockShared(&g_hookLock);
+    previousWndProc = g_hookState.previousWndProc;
+    ReleaseSRWLockShared(&g_hookLock);
+
+    StopHookThread();
+    AcquireSRWLockExclusive(&g_hookLock);
+    ClearHookState();
+    ReleaseSRWLockExclusive(&g_hookLock);
+    RestoreWindowProc(window, previousWndProc);
+    if (previousWndProc != nullptr) {
+      return CallWindowProcW(previousWndProc, window, message, wParam, lParam);
+    }
+  }
+
+  return CallPreviousWindowProc(window, message, wParam, lParam);
+}
+
+bool IsPrtScnMessage(WPARAM wParam, LPARAM lParam) {
+  const auto* info = reinterpret_cast<KBDLLHOOKSTRUCT*>(lParam);
+  if (info == nullptr || info->vkCode != VK_SNAPSHOT) {
+    return false;
+  }
+
+  if ((info->flags & LLKHF_INJECTED) != 0) {
+    // helper 的 SendInput 会带 injected 标记, 必须忽略以避免递归
+    return false;
+  }
+
+  return wParam == WM_KEYDOWN || wParam == WM_KEYUP || wParam == WM_SYSKEYDOWN ||
+         wParam == WM_SYSKEYUP;
+}
+
+LRESULT CALLBACK PrintScreenHookProc(int code, WPARAM wParam, LPARAM lParam) {
+  if (code < 0 || !IsPrtScnMessage(wParam, lParam)) {
+    return CallNextHookEx(nullptr, code, wParam, lParam);
+  }
+
+  const bool isKeyDown = wParam == WM_KEYDOWN || wParam == WM_SYSKEYDOWN;
+  const bool isKeyUp = wParam == WM_KEYUP || wParam == WM_SYSKEYUP;
+
+  AcquireSRWLockExclusive(&g_hookLock);
+  if (isKeyUp && g_hookState.suppressKeyUp) {
+    g_hookState.suppressKeyUp = false;
+    ReleaseSRWLockExclusive(&g_hookLock);
+    return 1;
+  }
+  ReleaseSRWLockExclusive(&g_hookLock);
+
+  if (!isKeyDown || !IsPlainModifierState() || !IsSourceForeground()) {
+    return CallNextHookEx(nullptr, code, wParam, lParam);
+  }
+
+  // 只捕获 Sparkle 前台时的裸 PrtScn, 组合键和其他前台应用保持原行为
+  AcquireSRWLockExclusive(&g_hookLock);
+  g_hookState.suppressKeyUp = true;
+  if (!g_hookState.forwarding) {
+    g_hookState.forwarding = true;
+    HWND window = g_hookState.window;
+    ReleaseSRWLockExclusive(&g_hookLock);
+
+    if (!PostMessageW(window, kForwardMessage, 0, 0)) {
+      AcquireSRWLockExclusive(&g_hookLock);
+      g_hookState.lastStatus = kForwardPostFailed;
+      g_hookState.forwardCount++;
+      g_hookState.forwarding = false;
+      ReleaseSRWLockExclusive(&g_hookLock);
+    }
+  } else {
+    ReleaseSRWLockExclusive(&g_hookLock);
+  }
+
+  return 1;
+}
+
+DWORD WINAPI ForwardThreadProc(void* param) {
+  HWND window = reinterpret_cast<HWND>(param);
+  const UINT status = ToForwardStatus(ForwardPrintScreen(window));
+  FinishForwardStatus(status);
+  return 0;
+}
+
+HMODULE GetCurrentModule() {
+  HMODULE module = nullptr;
+  GetModuleHandleExW(
+    GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+    reinterpret_cast<LPCWSTR>(&PrintScreenHookProc),
+    &module
+  );
+  return module;
+}
+
+DWORD WINAPI HookThreadProc(void*) {
+  SetThreadPriority(GetCurrentThread(), kHookThreadPriority);
+
+  // WH_KEYBOARD_LL 的回调依赖安装线程持续泵消息; 独立线程避免影响 Electron 主线程
+  MSG message;
+  PeekMessageW(&message, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+
+  HMODULE module = GetCurrentModule();
+  HHOOK keyboardHook = SetWindowsHookExW(WH_KEYBOARD_LL, PrintScreenHookProc, module, 0);
+
+  AcquireSRWLockExclusive(&g_hookLock);
+  g_hookState.keyboardHook = keyboardHook;
+  g_hookState.hookInstalled = keyboardHook != nullptr;
+  g_hookState.hookReady = true;
+  HANDLE readyEvent = g_hookState.hookReadyEvent;
+  ReleaseSRWLockExclusive(&g_hookLock);
+
+  if (readyEvent != nullptr) {
+    SetEvent(readyEvent);
+  }
+
+  if (keyboardHook == nullptr) {
+    return 0;
+  }
+
+  while (GetMessageW(&message, nullptr, 0, 0) > 0) {
+    TranslateMessage(&message);
+    DispatchMessageW(&message);
+  }
+
+  // 收到 WM_QUIT 后在安装线程内卸载 hook
+  UnhookWindowsHookEx(keyboardHook);
+
+  AcquireSRWLockExclusive(&g_hookLock);
+  if (g_hookState.keyboardHook == keyboardHook) {
+    g_hookState.keyboardHook = nullptr;
+    g_hookState.hookInstalled = false;
+  }
+  ReleaseSRWLockExclusive(&g_hookLock);
+
+  return 0;
+}
+
+bool InstallNativeHook(HWND window) {
+  if (!IsWindow(window)) {
+    return false;
+  }
+
+  UninstallHookState();
+
+  HANDLE readyEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+  if (readyEvent == nullptr) {
+    return false;
+  }
+
+  AcquireSRWLockExclusive(&g_hookLock);
+  g_hookState.window = window;
+  g_hookState.hookReadyEvent = readyEvent;
+  ReleaseSRWLockExclusive(&g_hookLock);
+
+  SetLastError(0);
+  WNDPROC previousWndProc = reinterpret_cast<WNDPROC>(
+    SetWindowLongPtrW(window, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(HookWndProc))
+  );
+  if (previousWndProc == nullptr && GetLastError() != 0) {
+    CloseHandle(readyEvent);
+    AcquireSRWLockExclusive(&g_hookLock);
+    ClearHookState();
+    ReleaseSRWLockExclusive(&g_hookLock);
+    return false;
+  }
+
+  AcquireSRWLockExclusive(&g_hookLock);
+  g_hookState.previousWndProc = previousWndProc;
+  ReleaseSRWLockExclusive(&g_hookLock);
+
+  DWORD hookThreadId = 0;
+  HANDLE hookThread = CreateThread(nullptr, 0, HookThreadProc, nullptr, 0, &hookThreadId);
+  if (hookThread == nullptr) {
+    CloseHandle(readyEvent);
+    RestoreWindowProc(window, previousWndProc);
+    AcquireSRWLockExclusive(&g_hookLock);
+    ClearHookState();
+    ReleaseSRWLockExclusive(&g_hookLock);
+    return false;
+  }
+
+  AcquireSRWLockExclusive(&g_hookLock);
+  g_hookState.hookThread = hookThread;
+  g_hookState.hookThreadId = hookThreadId;
+  ReleaseSRWLockExclusive(&g_hookLock);
+
+  const DWORD waitResult = WaitForSingleObject(readyEvent, kHookThreadStartupTimeoutMs);
+  CloseHandle(readyEvent);
+
+  AcquireSRWLockExclusive(&g_hookLock);
+  g_hookState.hookReadyEvent = nullptr;
+  const bool ok = waitResult == WAIT_OBJECT_0 && g_hookState.hookInstalled;
+  ReleaseSRWLockExclusive(&g_hookLock);
+
+  if (!ok) {
+    UninstallHookState();
+  }
+
+  return ok;
+}
+
+napi_value InstallHook(napi_env env, napi_callback_info info) {
+  if (!ResolveNapi()) {
+    return nullptr;
+  }
+
+  HWND window = nullptr;
+  if (!GetWindowArg(env, info, &window)) {
+    return ThrowError(env, "invalid installHook arguments");
+  }
+
+  return BooleanValue(env, InstallNativeHook(window));
+}
+
+napi_value UninstallHook(napi_env env, napi_callback_info info) {
+  if (!ResolveNapi()) {
+    return nullptr;
+  }
+
+  HWND window = nullptr;
+  if (!GetWindowArg(env, info, &window)) {
+    return ThrowError(env, "invalid uninstallHook arguments");
+  }
+
+  const bool ok = g_hookState.window == window;
+  if (ok) {
+    UninstallHookState();
+  }
+  return BooleanValue(env, ok);
+}
+
+napi_value ForwardPrtScn(napi_env env, napi_callback_info info) {
+  if (!ResolveNapi()) {
+    return nullptr;
+  }
+
+  HWND window = nullptr;
+  if (!GetWindowArg(env, info, &window)) {
+    return ThrowError(env, "invalid forwardPrtScn arguments");
+  }
+
+  return Uint32Value(env, ToForwardStatus(ForwardPrintScreen(window)));
+}
+
+napi_value CanForwardPrtScn(napi_env env, napi_callback_info info) {
+  if (!ResolveNapi()) {
+    return nullptr;
+  }
+
+  HWND window = nullptr;
+  if (!GetWindowArg(env, info, &window)) {
+    return ThrowError(env, "invalid canForwardPrtScn arguments");
+  }
+
+  return BooleanValue(env, CanForwardPrintScreen(window));
+}
+
+napi_value GetForwardCount(napi_env env, napi_callback_info) {
+  if (!ResolveNapi()) {
+    return nullptr;
+  }
+
+  AcquireSRWLockShared(&g_hookLock);
+  const UINT count = g_hookState.forwardCount;
+  ReleaseSRWLockShared(&g_hookLock);
+
+  return Uint32Value(env, count);
+}
+
+napi_value GetLastStatus(napi_env env, napi_callback_info) {
+  if (!ResolveNapi()) {
+    return nullptr;
+  }
+
+  AcquireSRWLockShared(&g_hookLock);
+  const UINT status = g_hookState.lastStatus;
+  ReleaseSRWLockShared(&g_hookLock);
+
+  return Uint32Value(env, status);
+}
+
+void SetFunction(napi_env env, napi_value exports, const char* name, napi_callback callback) {
+  napi_value function = nullptr;
+  if (g_napi.createFunction(env, name, static_cast<size_t>(-1), callback, nullptr, &function) == 0) {
+    g_napi.setNamedProperty(env, exports, name, function);
+  }
+}
+
+}
+
+extern "C" __declspec(dllexport) int __cdecl node_api_module_get_api_version_v1() {
+  return 6;
+}
+
+extern "C" __declspec(dllexport) napi_value __cdecl napi_register_module_v1(
+  napi_env env,
+  napi_value exports
+) {
+  if (!ResolveNapi()) {
+    return exports;
+  }
+
+  SetFunction(env, exports, "installHook", InstallHook);
+  SetFunction(env, exports, "uninstallHook", UninstallHook);
+  SetFunction(env, exports, "forwardPrtScn", ForwardPrtScn);
+  SetFunction(env, exports, "canForwardPrtScn", CanForwardPrtScn);
+  SetFunction(env, exports, "getForwardCount", GetForwardCount);
+  SetFunction(env, exports, "getLastStatus", GetLastStatus);
+  return exports;
+}

--- a/src/main/utils/elevation.ts
+++ b/src/main/utils/elevation.ts
@@ -5,13 +5,13 @@ const execFilePromise = promisify(execFile)
 
 let isAdminCached: boolean | null = null
 
-async function isRunningAsAdmin(): Promise<boolean> {
+export async function isRunningAsAdmin(): Promise<boolean> {
   if (isAdminCached !== null) {
     return isAdminCached
   }
 
   try {
-    await execFilePromise('net', ['session'], { timeout: 2000 })
+    await execFilePromise('net', ['session'], { timeout: 2000, windowsHide: true })
     isAdminCached = true
     return true
   } catch {

--- a/src/main/utils/template.ts
+++ b/src/main/utils/template.ts
@@ -55,6 +55,7 @@ export const defaultConfig: AppConfig = {
   disableNftables: false,
   safePaths: [],
   disableGPU: process.platform === 'win32' && parseInt(os.release().split('.')[2], 10) <= 20000,
+  disablePrintScreenCompatibility: false,
   proxyDisplayLayout: 'double',
   groupDisplayLayout: 'double',
   showGroupSelectedProxy: false,

--- a/src/shared/types/app.d.ts
+++ b/src/shared/types/app.d.ts
@@ -144,6 +144,7 @@ interface AppConfig {
   displayIcon?: boolean
   displayAppName?: boolean
   disableGPU: boolean
+  disablePrintScreenCompatibility?: boolean
   disableAnimation?: boolean
 }
 


### PR DESCRIPTION
修复 Windows 下 Sparkle 以管理员权限运行时, 按键 PrtScn 无法按预期使用截图的问题

问题原因: Windows UIPI
修复方法: 在 Sparkle 窗口聚焦时 hook PrtScn, 启动一个普通权限的几乎不可见窗口触发 PrtScn 以达到绕过 UIPI 限制的目的

该兼容逻辑只在 Windows 且 Sparkle 以管理员权限运行时启用, 其他情况保持原有行为
额外产物相当轻量: prtscnhelper.exe 5KB prtscnhook.node 13KB
构建时由 scripts/prepare.ts 编译生成 prtscnhook.node 和 prtscnhelper.exe, 仅依赖Win32 API 和 N-API, 应当不需要任何额外设置
已实际测试确认有效