### PR TITLE
修复一批功能相关问题

### DIFF
--- a/src/main/config/app.ts
+++ b/src/main/config/app.ts
@@ -63,12 +63,13 @@ export async function getAppConfig(force = false): Promise<AppConfig> {
 
 export async function patchAppConfig(patch: Partial<AppConfig>): Promise<AppConfig> {
   const previousPromise = writePromise
-  writePromise = (async () => {
+  const currentPromise = (async () => {
     await previousPromise
     appConfig = deepMerge(appConfig, patch)
     await safeWriteConfig(stringifyYaml(appConfig))
   })()
-  await writePromise
+  writePromise = currentPromise.catch(() => {})
+  await currentPromise
   return appConfig
 }
 

--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -62,6 +62,7 @@ const ctlParam = process.platform === 'win32' ? '-ext-ctl-pipe' : '-ext-ctl-unix
 const serviceConnectionRetryInterval = 500
 const tailscaleAuthNotificationKeyPrefix = 'tailscale-auth:'
 const directCoreLogLineLimit = 16 * 1024
+const coreLogReadyTimeout = 30000
 
 const directCoreState = {
   child: undefined as ChildProcess | undefined,
@@ -516,13 +517,37 @@ export async function startCore(detached = false): Promise<Promise<void>[]> {
     let controllerReady = false
 
     return new Promise((resolve, reject) => {
+      let settled = false
+
+      const settleResolve = (value: Promise<void>[]): void => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        resolve(value)
+      }
+
+      const settleReject = (reason?: unknown): void => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        reject(reason)
+      }
+
+      const timer = setTimeout(() => {
+        settleReject(new Error(`等待内核启动超时：${coreLogReadyTimeout}ms`))
+      }, coreLogReadyTimeout)
+
+      child.once('close', (code, signal) => {
+        settleReject(new Error(`内核启动失败，code: ${code}, signal: ${signal}`))
+      })
+
       child.stdout?.on('data', async (data) => {
         const str = data.toString()
-        await handleCoreOutput(str, reject)
+        await handleCoreOutput(str, settleReject)
 
         if (!controllerReady && isControllerReadyLog(str)) {
           controllerReady = true
-          resolve([
+          settleResolve([
             new Promise((resolve, reject) => {
               const handleProviderInitialization = async (logLine: string): Promise<void> => {
                 providerTracker.track(logLine)
@@ -546,6 +571,12 @@ export async function startCore(detached = false): Promise<Promise<void>[]> {
               child.stdout?.on('data', (data) => {
                 if (!initialized) {
                   handleProviderInitialization(data.toString()).catch(reject)
+                }
+              })
+
+              child.once('close', (code, signal) => {
+                if (!initialized) {
+                  reject(new Error(`内核启动失败，code: ${code}, signal: ${signal}`))
                 }
               })
             })
@@ -742,8 +773,12 @@ export async function startNetworkDetection(): Promise<void> {
   await startNetworkDetectionController({
     shouldStartCore: (networkDownHandled) => networkDownHandled && !directCoreState.child,
     startCore: async () => {
-      const promises = await startCore()
-      await Promise.all(promises)
+      try {
+        const promises = await startCore()
+        await Promise.all(promises)
+      } catch (error) {
+        await appendAppLog(`[Manager]: network detection start core failed, ${error}\n`)
+      }
     },
     stopCore
   })

--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -604,9 +604,9 @@ export async function stopCore(force = false): Promise<void> {
   }
 
   const child = directCoreState.child
-  if (child && !child.killed) {
-    await stopChildProcess(child)
+  if (child) {
     directCoreState.child = undefined
+    await stopChildProcess(child)
   }
 
   await getAxios(true).catch(() => {})
@@ -740,8 +740,7 @@ export async function quitWithoutCore(): Promise<void> {
 
 export async function startNetworkDetection(): Promise<void> {
   await startNetworkDetectionController({
-    shouldStartCore: (networkDownHandled) =>
-      (networkDownHandled && !directCoreState.child) || Boolean(directCoreState.child?.killed),
+    shouldStartCore: (networkDownHandled) => networkDownHandled && !directCoreState.child,
     startCore: async () => {
       const promises = await startCore()
       await Promise.all(promises)

--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -75,7 +75,7 @@ const serviceCoreRuntime = createServiceCoreRuntime({
   resetDirectCoreRetry: () => {
     directCoreState.retry = 10
   },
-  startCore: (detached) => startCore(detached)
+  startCore: (detached) => startCoreImpl(detached)
 })
 
 type CoreLogNotification = AppNotificationPayload & {
@@ -320,7 +320,25 @@ async function getServiceStatusAfterConnectionError(): Promise<
   }
 }
 
-export async function startCore(detached = false): Promise<Promise<void>[]> {
+let lifecycleChain: Promise<unknown> = Promise.resolve()
+
+function enqueueLifecycle<T>(task: () => Promise<T>): Promise<T> {
+  const result = lifecycleChain.then(
+    () => task(),
+    () => task()
+  )
+  lifecycleChain = result.then(
+    () => {},
+    () => {}
+  )
+  return result
+}
+
+export function startCore(detached = false): Promise<Promise<void>[]> {
+  return enqueueLifecycle(() => startCoreImpl(detached))
+}
+
+async function startCoreImpl(detached = false): Promise<Promise<void>[]> {
   const {
     core = 'mihomo',
     corePermissionMode = 'elevated',
@@ -347,7 +365,7 @@ export async function startCore(detached = false): Promise<Promise<void>[]> {
   } catch (error) {
     if (core === 'system') {
       await patchAppConfig({ core: 'mihomo' })
-      return startCore(detached)
+      return startCoreImpl(detached)
     }
     throw error
   }
@@ -370,7 +388,7 @@ export async function startCore(detached = false): Promise<Promise<void>[]> {
     }
   }
   if (!serviceCoreRunning) {
-    await stopCore()
+    await stopCoreImpl()
   }
   setMihomoLogSource('out')
   if (tun?.enable && autoSetDNSMode !== 'none') {
@@ -608,7 +626,11 @@ export async function startCore(detached = false): Promise<Promise<void>[]> {
   return coreStartupMode === 'post-up' ? waitForCoreReadyByHook() : waitForCoreReadyByLog()
 }
 
-export async function stopCore(force = false): Promise<void> {
+export function stopCore(force = false): Promise<void> {
+  return enqueueLifecycle(() => stopCoreImpl(force))
+}
+
+async function stopCoreImpl(force = false): Promise<void> {
   serviceCoreRuntime.pauseAutoResume()
 
   try {
@@ -738,13 +760,17 @@ function clearTailscaleAuthNotifications(name?: string): void {
 
 export async function restartCore(): Promise<void> {
   try {
-    clearTailscaleAuthNotifications()
-    await stopCore()
-    const promises = await startCore()
+    const promises = await enqueueLifecycle(() => restartCoreImpl())
     await Promise.all(promises)
   } catch (e) {
     void showNotification({ title: '内核启动出错', body: `${e}`, variant: 'danger' })
   }
+}
+
+async function restartCoreImpl(): Promise<Promise<void>[]> {
+  clearTailscaleAuthNotifications()
+  await stopCoreImpl()
+  return startCoreImpl()
 }
 
 export async function keepCoreAlive(): Promise<void> {

--- a/src/main/core/mihomoApi.ts
+++ b/src/main/core/mihomoApi.ts
@@ -41,16 +41,10 @@ function closeWebSocket(ws: WebSocket): void {
 export const getAxios = async (force: boolean = false): Promise<AxiosInstance> => {
   const { corePermissionMode = 'elevated' } = await getAppConfig()
   const nextMode = corePermissionMode === 'service' ? 'service' : 'direct'
-  const currentSocketPath = nextMode === 'service' ? serviceIpcPath() : mihomoIpcPath()
   const currentBaseURL =
     nextMode === 'service' ? 'http://localhost/core/controller' : 'http://localhost'
 
-  if (
-    axiosIns &&
-    (axiosIns.defaults.socketPath !== currentSocketPath ||
-      axiosIns.defaults.baseURL !== currentBaseURL ||
-      axiosMode !== nextMode)
-  ) {
+  if (axiosIns && (axiosIns.defaults.baseURL !== currentBaseURL || axiosMode !== nextMode)) {
     force = true
   }
 
@@ -62,7 +56,7 @@ export const getAxios = async (force: boolean = false): Promise<AxiosInstance> =
   } else {
     axiosIns = axios.create({
       baseURL: currentBaseURL,
-      socketPath: currentSocketPath,
+      socketPath: mihomoIpcPath(),
       timeout: 15000
     })
 

--- a/src/main/core/network.ts
+++ b/src/main/core/network.ts
@@ -96,12 +96,7 @@ export async function recoverDNS(): Promise<void> {
 export async function startNetworkDetectionController(
   controller: NetworkCoreController
 ): Promise<void> {
-  const {
-    onlyActiveDevice = false,
-    networkDetectionBypass = [],
-    networkDetectionInterval = 10,
-    sysProxy = { enable: false }
-  } = await getAppConfig()
+  const { networkDetectionBypass = [], networkDetectionInterval = 10 } = await getAppConfig()
   const { tun: { device = process.platform === 'darwin' ? undefined : 'mihomo' } = {} } =
     await getControledMihomoConfig()
   if (networkDetectionTimer) {
@@ -112,6 +107,7 @@ export async function startNetworkDetectionController(
   )
 
   networkDetectionTimer = setInterval(async () => {
+    const { onlyActiveDevice = false, sysProxy = { enable: false } } = await getAppConfig()
     if (isAnyNetworkInterfaceUp(extendedBypass) && net.isOnline()) {
       if (controller.shouldStartCore(networkDownHandled)) {
         await controller.startCore()

--- a/src/main/core/network.ts
+++ b/src/main/core/network.ts
@@ -5,6 +5,7 @@ import { promisify } from 'util'
 import { getAppConfig, getControledMihomoConfig, patchAppConfig } from '../config'
 import { setSysDns } from '../service/api'
 import { triggerSysProxy } from '../sys/sysproxy'
+import { appendAppLog } from '../utils/log'
 
 export interface NetworkCoreController {
   shouldStartCore: (networkDownHandled: boolean) => boolean
@@ -111,12 +112,20 @@ export async function startNetworkDetectionController(
     if (isAnyNetworkInterfaceUp(extendedBypass) && net.isOnline()) {
       if (controller.shouldStartCore(networkDownHandled)) {
         await controller.startCore()
-        if (sysProxy.enable) triggerSysProxy(true, onlyActiveDevice)
+        if (sysProxy.enable) {
+          triggerSysProxy(true, onlyActiveDevice).catch((error) => {
+            appendAppLog(`[Network]: enable sysproxy failed, ${error}\n`).catch(() => {})
+          })
+        }
         networkDownHandled = false
       }
     } else {
       if (!networkDownHandled) {
-        if (sysProxy.enable) triggerSysProxy(false, onlyActiveDevice, true)
+        if (sysProxy.enable) {
+          triggerSysProxy(false, onlyActiveDevice, true).catch((error) => {
+            appendAppLog(`[Network]: disable sysproxy failed, ${error}\n`).catch(() => {})
+          })
+        }
         await controller.stopCore()
         networkDownHandled = true
       }

--- a/src/main/core/permission-check.ts
+++ b/src/main/core/permission-check.ts
@@ -1,4 +1,6 @@
-import { execFileSync } from 'child_process'
+import { statSync } from 'fs'
+
+const S_ISUID = 0o4000
 
 export function hasSetuidPermission(permissions: string): boolean {
   return permissions.includes('s') || permissions.includes('S')
@@ -7,9 +9,7 @@ export function hasSetuidPermission(permissions: string): boolean {
 export function checkCorePermissionPathSync(corePath: string): boolean {
   if (process.platform === 'win32') return true
   try {
-    const stdout = execFileSync('ls', ['-l', corePath], { encoding: 'utf8' })
-    const permissions = stdout.trim().split(/\s+/)[0]
-    return hasSetuidPermission(permissions)
+    return (statSync(corePath).mode & S_ISUID) !== 0
   } catch {
     return false
   }

--- a/src/main/core/process-control.ts
+++ b/src/main/core/process-control.ts
@@ -1,9 +1,18 @@
 import type { ChildProcess } from 'child_process'
 import { appendAppLog } from '../utils/log'
 
+function isProcessAlive(pid: number): boolean {
+  try {
+    globalThis.process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
 export async function stopChildProcess(process: ChildProcess): Promise<void> {
   return new Promise<void>((resolve) => {
-    if (!process || process.killed) {
+    if (!process || process.exitCode !== null || process.signalCode !== null) {
       resolve()
       return
     }
@@ -19,7 +28,7 @@ export async function stopChildProcess(process: ChildProcess): Promise<void> {
     let isResolved = false
     const timers: NodeJS.Timeout[] = []
 
-    const resolveOnce = async (): Promise<void> => {
+    const resolveOnce = (): void => {
       if (!isResolved) {
         isResolved = true
 
@@ -33,39 +42,36 @@ export async function stopChildProcess(process: ChildProcess): Promise<void> {
 
     try {
       process.kill('SIGINT')
-
-      const timer1 = setTimeout(async () => {
-        if (!process.killed && !isResolved) {
-          try {
-            if (pid) {
-              globalThis.process.kill(pid, 0)
-              process.kill('SIGTERM')
-            }
-          } catch {
-            await resolveOnce()
-          }
-        }
-      }, 3000)
-      timers.push(timer1)
-
-      const timer2 = setTimeout(async () => {
-        if (!process.killed && !isResolved) {
-          try {
-            if (pid) {
-              globalThis.process.kill(pid, 0)
-              process.kill('SIGKILL')
-              await appendAppLog(`[Manager]: Force killed process ${pid} with SIGKILL\n`)
-            }
-          } catch {
-            // ignore
-          }
-          await resolveOnce()
-        }
-      }, 6000)
-      timers.push(timer2)
-    } catch (error) {
-      resolveOnce()
-      return
+    } catch {
+      // ignore
     }
+
+    const timer1 = setTimeout(() => {
+      if (isResolved) return
+      if (!isProcessAlive(pid)) {
+        resolveOnce()
+        return
+      }
+      try {
+        process.kill('SIGTERM')
+      } catch {
+        // ignore
+      }
+    }, 3000)
+    timers.push(timer1)
+
+    const timer2 = setTimeout(() => {
+      if (isResolved) return
+      if (isProcessAlive(pid)) {
+        try {
+          process.kill('SIGKILL')
+          appendAppLog(`[Manager]: Force killed process ${pid} with SIGKILL\n`).catch(() => {})
+        } catch {
+          // ignore
+        }
+      }
+      resolveOnce()
+    }, 6000)
+    timers.push(timer2)
   })
 }

--- a/src/main/core/profileUpdater.ts
+++ b/src/main/core/profileUpdater.ts
@@ -38,6 +38,10 @@ export async function initProfileUpdater(): Promise<void> {
         }
       }
 
+      if (intervalPool[item.id]) {
+        clearTimeout(intervalPool[item.id])
+      }
+
       intervalPool[item.id] = setTimeout(
         async () => {
           try {
@@ -60,6 +64,10 @@ export async function initProfileUpdater(): Promise<void> {
       } catch (e) {
         // ignore
       }
+    }
+
+    if (intervalPool[currentItem.id]) {
+      clearTimeout(intervalPool[currentItem.id])
     }
 
     intervalPool[currentItem.id] = setTimeout(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -299,6 +299,7 @@ export async function createWindow(appConfig?: AppConfig): Promise<void> {
     mainWindow.on('move', windowStateManager.save)
 
     mainWindow.on('session-end', async () => {
+      disableSysProxySync(true)
       await triggerSysProxy(false, false, true)
       await stopCore()
     })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@ import { registerIpcMainHandlers } from './utils/ipc'
 import { app, shell, BrowserWindow, Menu } from 'electron'
 import { getAppConfig } from './config'
 import { quitWithoutCore, startCore, stopCore } from './core/manager'
+import { stopNetworkDetection } from './core/network'
 import { disableSysProxySync, triggerSysProxy } from './sys/sysproxy'
 import icon from '../../resources/icon.png?asset'
 import { createTray } from './resolve/tray'
@@ -300,6 +301,7 @@ export async function createWindow(appConfig?: AppConfig): Promise<void> {
 
     mainWindow.on('session-end', async () => {
       disableSysProxySync(true)
+      await stopNetworkDetection()
       await triggerSysProxy(false, false, true)
       await stopCore()
     })

--- a/src/main/resolve/autoUpdater.ts
+++ b/src/main/resolve/autoUpdater.ts
@@ -84,6 +84,21 @@ async function ensureWindowsInstallerTempSpace(): Promise<void> {
 
 export async function downloadAndInstallUpdate(version: string): Promise<void> {
   let appUpdateInstalling = false
+  let sysProxyPaused = false
+  const pauseSysProxy = async (): Promise<void> => {
+    sysProxyPaused = true
+    await triggerSysProxy(false, false)
+  }
+  const resumeSysProxy = async (): Promise<void> => {
+    if (!sysProxyPaused) return
+    sysProxyPaused = false
+    try {
+      const { sysProxy, onlyActiveDevice = false } = await getAppConfig()
+      if (sysProxy.enable) await triggerSysProxy(true, onlyActiveDevice)
+    } catch (error) {
+      await appendAppLog(`[Updater]: restore sysproxy failed, ${error}\n`).catch(() => {})
+    }
+  }
   const { 'mixed-port': mixedPort = 7890 } = await getControledMihomoConfig()
   let releaseTag = version
   if (version.includes('beta')) {
@@ -179,7 +194,7 @@ export async function downloadAndInstallUpdate(version: string): Promise<void> {
 
     if (file.endsWith('.exe')) {
       await ensureWindowsInstallerTempSpace()
-      await triggerSysProxy(false, false)
+      await pauseSysProxy()
       await pauseServiceFallbackForAppUpdate()
       spawn(path.join(dataDir(), file), ['/S', '--updated', '--force-run'], {
         detached: true,
@@ -188,7 +203,7 @@ export async function downloadAndInstallUpdate(version: string): Promise<void> {
       appUpdateInstalling = true
     }
     if (file.endsWith('.7z')) {
-      await triggerSysProxy(false, false)
+      await pauseSysProxy()
       await pauseServiceFallbackForAppUpdate()
       await stopServiceForPortableUpdate()
       await copyFile(path.join(resourcesFilesDir(), '7za.exe'), path.join(dataDir(), '7za.exe'))
@@ -209,7 +224,7 @@ export async function downloadAndInstallUpdate(version: string): Promise<void> {
     }
     if (file.endsWith('.pkg')) {
       try {
-        await triggerSysProxy(false, false)
+        await pauseSysProxy()
         await pauseServiceFallbackForAppUpdate()
         const execPromise = promisify(exec)
         const shell = `installer -pkg ${path.join(dataDir(), file).replace(' ', '\\\\ ')} -target /`
@@ -221,12 +236,14 @@ export async function downloadAndInstallUpdate(version: string): Promise<void> {
         app.quit()
       } catch {
         await clearAppUpdateServiceFallbackPause()
+        await resumeSysProxy()
         shell.openPath(path.join(dataDir(), file))
       }
     }
   } catch (e) {
     if (!appUpdateInstalling) {
       await clearAppUpdateServiceFallbackPause()
+      await resumeSysProxy()
     }
     await rm(path.join(dataDir(), file), { force: true })
     if (axios.isCancel(e)) {

--- a/src/main/sys/autoRun.ts
+++ b/src/main/sys/autoRun.ts
@@ -8,6 +8,14 @@ import path from 'path'
 
 const appName = 'sparkle'
 
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
 const taskXml = `<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <Triggers>
@@ -43,8 +51,8 @@ const taskXml = `<?xml version="1.0" encoding="UTF-16"?>
   </Settings>
   <Actions Context="Author">
     <Exec>
-      <Command>"${path.join(taskDir(), `sparkle-run.exe`)}"</Command>
-      <Arguments>"${exePath()}"</Arguments>
+      <Command>"${escapeXml(path.join(taskDir(), `sparkle-run.exe`))}"</Command>
+      <Arguments>"${escapeXml(exePath())}"</Arguments>
     </Exec>
   </Actions>
 </Task>

--- a/src/main/sys/sysproxy.ts
+++ b/src/main/sys/sysproxy.ts
@@ -238,9 +238,9 @@ export function disableSysProxySync(useRegistry = false): void {
   if (process.platform !== 'win32') return
 
   try {
-    execFileSync(servicePath(), ['disable', ...registryArgs(useRegistry)], {
+    execFileSync(servicePath(), ['sysproxy', 'disable', ...registryArgs(useRegistry)], {
       stdio: 'ignore',
-      timeout: 5000
+      timeout: 3000
     })
   } catch {
     // ignore

--- a/src/main/sys/sysproxy.ts
+++ b/src/main/sys/sysproxy.ts
@@ -39,10 +39,11 @@ export async function triggerSysProxy(
     if (net.isOnline()) {
       await setSysProxy(onlyActiveDevice, useRegistry)
     } else {
-      triggerSysProxyTimer = setTimeout(
-        () => triggerSysProxy(enable, onlyActiveDevice, useRegistry),
-        5000
-      )
+      triggerSysProxyTimer = setTimeout(() => {
+        triggerSysProxy(enable, onlyActiveDevice, useRegistry).catch((error) => {
+          appendAppLog(`[Sysproxy]: retry enable failed, ${error}\n`).catch(() => {})
+        })
+      }, 5000)
     }
   } else {
     await disableSysProxy(onlyActiveDevice, useRegistry)

--- a/src/main/sys/sysproxy.ts
+++ b/src/main/sys/sysproxy.ts
@@ -31,11 +31,14 @@ export async function triggerSysProxy(
   onlyActiveDevice: boolean,
   useRegistry = false
 ): Promise<void> {
+  if (triggerSysProxyTimer) {
+    clearTimeout(triggerSysProxyTimer)
+    triggerSysProxyTimer = null
+  }
   if (enable) {
     if (net.isOnline()) {
       await setSysProxy(onlyActiveDevice, useRegistry)
     } else {
-      if (triggerSysProxyTimer) clearTimeout(triggerSysProxyTimer)
       triggerSysProxyTimer = setTimeout(
         () => triggerSysProxy(enable, onlyActiveDevice, useRegistry),
         5000

--- a/src/main/utils/ipc.ts
+++ b/src/main/utils/ipc.ts
@@ -183,7 +183,7 @@ async function patchAppConfigWithServiceSync(patch: Partial<AppConfig>): Promise
     save_logs: saveLogs,
     max_log_file_size_mb: maxLogFileSizeMB
   }).catch((error) => {
-    void appendAppLog(`[Service]: sync core log config failed, ${error}\n`)
+    appendAppLog(`[Service]: sync core log config failed, ${error}\n`).catch(() => {})
   })
 
   return nextConfig

--- a/src/main/utils/log.ts
+++ b/src/main/utils/log.ts
@@ -72,6 +72,11 @@ function getWriteStream(target: LogTarget): WriteStream {
   }
 
   const stream = createWriteStream(nextPath, { flags: 'a', highWaterMark: logStreamHighWaterMark })
+  stream.on('error', () => {
+    if (streamMap.get(target)?.stream === stream) {
+      streamMap.delete(target)
+    }
+  })
   streamMap.set(target, { path: nextPath, stream })
   return stream
 }
@@ -401,7 +406,7 @@ export function createLogWritable(target: LogTarget, type: LogLevel = 'info'): W
       }
       void appendLog(target, content).then(
         () => callback(),
-        (error) => callback(error as Error)
+        () => callback()
       )
     },
     writev(chunks, callback) {
@@ -414,7 +419,7 @@ export function createLogWritable(target: LogTarget, type: LogLevel = 'info'): W
       }
       void appendLog(target, content).then(
         () => callback(),
-        (error) => callback(error as Error)
+        () => callback()
       )
     },
     final(callback) {

--- a/src/renderer/src/components/mihomo/permission-modal.tsx
+++ b/src/renderer/src/components/mihomo/permission-modal.tsx
@@ -62,7 +62,7 @@ const PermissionModal: React.FC<Props> = (props) => {
     coreName: 'mihomo' | 'mihomo-alpha',
     isGrant: boolean
   ): Promise<void> => {
-    setLoading({ ...loading, [coreName]: true })
+    setLoading((prev) => ({ ...prev, [coreName]: true }))
     try {
       if (isGrant) {
         await manualGrantCorePermition([coreName])
@@ -80,7 +80,7 @@ const PermissionModal: React.FC<Props> = (props) => {
       }
       notify(e, { variant: 'danger' })
     } finally {
-      setLoading({ ...loading, [coreName]: false })
+      setLoading((prev) => ({ ...prev, [coreName]: false }))
     }
   }
 

--- a/src/renderer/src/components/profiles/edit-file-modal.tsx
+++ b/src/renderer/src/components/profiles/edit-file-modal.tsx
@@ -5,6 +5,7 @@ import { BaseEditor } from '../base/base-editor-lazy'
 import { getProfileStr, setProfileStr } from '@renderer/utils/ipc'
 import { useNavigate } from 'react-router-dom'
 import { useAppConfig } from '@renderer/hooks/use-app-config'
+import { notify } from '@renderer/utils/notification'
 import ConfirmModal from '../base/base-confirm'
 
 interface Props {
@@ -19,6 +20,7 @@ const EditFileModal: React.FC<Props> = (props) => {
   const [currData, setCurrData] = useState('')
   const [originalData, setOriginalData] = useState('')
   const [isLoading, setIsLoading] = useState(true)
+  const [isSaving, setIsSaving] = useState(false)
   const [isDiff, setIsDiff] = useState(false)
   const [sideBySide, setSideBySide] = useState(false)
   const [isConfirmOpen, setIsConfirmOpen] = useState(false)
@@ -31,6 +33,18 @@ const EditFileModal: React.FC<Props> = (props) => {
       setIsConfirmOpen(true)
     } else {
       onClose()
+    }
+  }
+
+  const save = async (): Promise<void> => {
+    setIsSaving(true)
+    try {
+      await setProfileStr(id, currData)
+      onClose()
+    } catch (e) {
+      notify(e, { variant: 'danger' })
+    } finally {
+      setIsSaving(false)
     }
   }
 
@@ -127,14 +141,7 @@ const EditFileModal: React.FC<Props> = (props) => {
                 <Button size="sm" variant="secondary" onPress={handleClose}>
                   取消
                 </Button>
-                <Button
-                  size="sm"
-                  variant="primary"
-                  onPress={async () => {
-                    await setProfileStr(id, currData)
-                    onClose()
-                  }}
-                >
+                <Button size="sm" variant="primary" isPending={isSaving} onPress={() => save()}>
                   保存
                 </Button>
               </div>

--- a/src/renderer/src/components/resources/proxy-provider.tsx
+++ b/src/renderer/src/components/resources/proxy-provider.tsx
@@ -57,11 +57,11 @@ const ProxyProvider: React.FC = () => {
   })
 
   useEffect(() => {
-    window.electron.ipcRenderer.on('core-started', () => {
+    const unsubscribeCoreStarted = window.electron.ipcRenderer.on('core-started', () => {
       mutate()
     })
     return (): void => {
-      window.electron.ipcRenderer.removeAllListeners('core-started')
+      unsubscribeCoreStarted()
     }
   }, [])
 

--- a/src/renderer/src/components/resources/rule-provider.tsx
+++ b/src/renderer/src/components/resources/rule-provider.tsx
@@ -60,11 +60,11 @@ const RuleProvider: React.FC = () => {
   })
 
   useEffect(() => {
-    window.electron.ipcRenderer.on('core-started', () => {
+    const unsubscribeCoreStarted = window.electron.ipcRenderer.on('core-started', () => {
       mutate()
     })
     return (): void => {
-      window.electron.ipcRenderer.removeAllListeners('core-started')
+      unsubscribeCoreStarted()
     }
   }, [])
 

--- a/src/renderer/src/components/settings/actions.tsx
+++ b/src/renderer/src/components/settings/actions.tsx
@@ -52,10 +52,10 @@ const Actions: React.FC = () => {
       setUpdateStatus(status)
     }
 
-    window.electron.ipcRenderer.on('update-status', handleUpdateStatus)
+    const unsubscribe = window.electron.ipcRenderer.on('update-status', handleUpdateStatus)
 
     return (): void => {
-      window.electron.ipcRenderer.removeAllListeners('update-status')
+      unsubscribe()
     }
   }, [])
 

--- a/src/renderer/src/components/sider/mihomo-core-card.tsx
+++ b/src/renderer/src/components/sider/mihomo-core-card.tsx
@@ -45,16 +45,19 @@ const MihomoCoreCard: React.FC<Props> = (props) => {
     const token = PubSub.subscribe('mihomo-core-changed', () => {
       mutate()
     })
-    window.electron.ipcRenderer.on('mihomoMemory', (_e, info: ControllerMemory) => {
-      setMem(info.inuse)
-    })
-    window.electron.ipcRenderer.on('core-started', () => {
+    const unsubscribeMihomoMemory = window.electron.ipcRenderer.on(
+      'mihomoMemory',
+      (_e, info: ControllerMemory) => {
+        setMem(info.inuse)
+      }
+    )
+    const unsubscribeCoreStarted = window.electron.ipcRenderer.on('core-started', () => {
       mutate()
     })
     return (): void => {
       PubSub.unsubscribe(token)
-      window.electron.ipcRenderer.removeAllListeners('mihomoMemory')
-      window.electron.ipcRenderer.removeAllListeners('core-started')
+      unsubscribeMihomoMemory()
+      unsubscribeCoreStarted()
     }
   }, [])
 

--- a/src/renderer/src/components/updater/updater-button.tsx
+++ b/src/renderer/src/components/updater/updater-button.tsx
@@ -39,10 +39,10 @@ const UpdaterButton: React.FC<Props> = (props) => {
       setUpdateStatus(status)
     }
 
-    window.electron.ipcRenderer.on('update-status', handleUpdateStatus)
+    const unsubscribe = window.electron.ipcRenderer.on('update-status', handleUpdateStatus)
 
     return (): void => {
-      window.electron.ipcRenderer.removeAllListeners('update-status')
+      unsubscribe()
     }
   }, [])
 

--- a/src/renderer/src/hooks/use-groups.tsx
+++ b/src/renderer/src/hooks/use-groups.tsx
@@ -16,15 +16,15 @@ export const GroupsProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   })
 
   React.useEffect(() => {
-    window.electron.ipcRenderer.on('groupsUpdated', () => {
+    const unsubscribeGroupsUpdated = window.electron.ipcRenderer.on('groupsUpdated', () => {
       mutate()
     })
-    window.electron.ipcRenderer.on('core-started', () => {
+    const unsubscribeCoreStarted = window.electron.ipcRenderer.on('core-started', () => {
       mutate()
     })
     return (): void => {
-      window.electron.ipcRenderer.removeAllListeners('groupsUpdated')
-      window.electron.ipcRenderer.removeAllListeners('core-started')
+      unsubscribeGroupsUpdated()
+      unsubscribeCoreStarted()
     }
   }, [])
 

--- a/src/renderer/src/hooks/use-rules.tsx
+++ b/src/renderer/src/hooks/use-rules.tsx
@@ -16,15 +16,15 @@ export const RulesProvider: React.FC<{ children: ReactNode }> = ({ children }) =
   })
 
   React.useEffect(() => {
-    window.electron.ipcRenderer.on('rulesUpdated', () => {
+    const unsubscribeRulesUpdated = window.electron.ipcRenderer.on('rulesUpdated', () => {
       mutate()
     })
-    window.electron.ipcRenderer.on('core-started', () => {
+    const unsubscribeCoreStarted = window.electron.ipcRenderer.on('core-started', () => {
       mutate()
     })
     return (): void => {
-      window.electron.ipcRenderer.removeAllListeners('rulesUpdated')
-      window.electron.ipcRenderer.removeAllListeners('core-started')
+      unsubscribeRulesUpdated()
+      unsubscribeCoreStarted()
     }
   }, [])
 

--- a/src/renderer/src/pages/connections.tsx
+++ b/src/renderer/src/pages/connections.tsx
@@ -332,6 +332,12 @@ const Connections: React.FC = () => {
         lastActiveTime.current.set(id, now)
       })
 
+      lastActiveTime.current.forEach((activeAt, id) => {
+        if (now - activeAt >= 1000) {
+          lastActiveTime.current.delete(id)
+        }
+      })
+
       const activeConns = info.connections.map((conn) => {
         const preConn = prevActiveMap.get(conn.id)
         const downloadSpeed = preConn

--- a/src/renderer/src/pages/override.tsx
+++ b/src/renderer/src/pages/override.tsx
@@ -102,58 +102,61 @@ const Override: React.FC = () => {
       event.stopPropagation()
       if (isProcessingDrop.current) return
       isProcessingDrop.current = true
-      const dataTransfer = event.dataTransfer
-      const file = dataTransfer?.files[0]
-      if (file) {
-        if (
-          file.name.endsWith('.js') ||
-          file.name.endsWith('.yml') ||
-          file.name.endsWith('.yaml') ||
-          file.name.endsWith('.json') ||
-          file.name.endsWith('.jsonc') ||
-          file.name.endsWith('.json5') ||
-          file.name.endsWith('.txt')
-        ) {
-          try {
-            const path = window.api.webUtils.getPathForFile(file)
-            const content = await readTextFile(path)
-            await addOverrideItem({
-              name: file.name,
-              type: 'local',
-              file: content,
-              ext: file.name.endsWith('.js') ? 'js' : 'yaml'
-            })
-          } catch (e) {
-            notify('文件导入失败' + e, { variant: 'danger' })
+      try {
+        const dataTransfer = event.dataTransfer
+        const file = dataTransfer?.files[0]
+        if (file) {
+          if (
+            file.name.endsWith('.js') ||
+            file.name.endsWith('.yml') ||
+            file.name.endsWith('.yaml') ||
+            file.name.endsWith('.json') ||
+            file.name.endsWith('.jsonc') ||
+            file.name.endsWith('.json5') ||
+            file.name.endsWith('.txt')
+          ) {
+            try {
+              const path = window.api.webUtils.getPathForFile(file)
+              const content = await readTextFile(path)
+              await addOverrideItem({
+                name: file.name,
+                type: 'local',
+                file: content,
+                ext: file.name.endsWith('.js') ? 'js' : 'yaml'
+              })
+            } catch (e) {
+              notify('文件导入失败' + e, { variant: 'danger' })
+            }
+          } else {
+            notify('不支持的文件类型', { variant: 'danger' })
           }
         } else {
-          notify('不支持的文件类型', { variant: 'danger' })
+          const droppedUrl =
+            dataTransfer
+              ?.getData('text/uri-list')
+              .split(/\r?\n/)
+              .find((value) => value && !value.startsWith('#')) ||
+            dataTransfer?.getData('text/plain').trim()
+          try {
+            const urlObj = new URL(droppedUrl || '')
+            if (urlObj.protocol !== 'http:' && urlObj.protocol !== 'https:') throw new Error()
+            setEditingItem({
+              id: '',
+              name: '',
+              type: 'remote',
+              url: droppedUrl,
+              ext: urlObj.pathname.endsWith('.js') ? 'js' : 'yaml',
+              updated: Date.now()
+            })
+            setShowEditModal(true)
+          } catch {
+            notify('未检测到有效的覆写链接', { variant: 'danger' })
+          }
         }
-      } else {
-        const droppedUrl =
-          dataTransfer
-            ?.getData('text/uri-list')
-            .split(/\r?\n/)
-            .find((value) => value && !value.startsWith('#')) ||
-          dataTransfer?.getData('text/plain').trim()
-        try {
-          const urlObj = new URL(droppedUrl || '')
-          if (urlObj.protocol !== 'http:' && urlObj.protocol !== 'https:') throw new Error()
-          setEditingItem({
-            id: '',
-            name: '',
-            type: 'remote',
-            url: droppedUrl,
-            ext: urlObj.pathname.endsWith('.js') ? 'js' : 'yaml',
-            updated: Date.now()
-          })
-          setShowEditModal(true)
-        } catch {
-          notify('未检测到有效的覆写链接', { variant: 'danger' })
-        }
+      } finally {
+        isProcessingDrop.current = false
+        setFileOver(false)
       }
-      isProcessingDrop.current = false
-      setFileOver(false)
     })
     return (): void => {
       pageRef.current?.removeEventListener('dragover', () => {})

--- a/src/renderer/src/pages/profiles.tsx
+++ b/src/renderer/src/pages/profiles.tsx
@@ -184,51 +184,54 @@ const Profiles: React.FC = () => {
     pageRef.current?.addEventListener('drop', async (event) => {
       event.preventDefault()
       event.stopPropagation()
-      const dataTransfer = event.dataTransfer
-      const file = dataTransfer?.files[0]
-      if (file) {
-        if (
-          file.name.endsWith('.yml') ||
-          file.name.endsWith('.yaml') ||
-          file.name.endsWith('.json') ||
-          file.name.endsWith('.jsonc') ||
-          file.name.endsWith('.json5') ||
-          file.name.endsWith('.txt')
-        ) {
-          try {
-            const path = window.api.webUtils.getPathForFile(file)
-            const content = await readTextFile(path)
-            await addProfileItem({ name: file.name, type: 'local', file: content })
-          } catch (e) {
-            notify('文件导入失败' + e, { variant: 'danger' })
+      try {
+        const dataTransfer = event.dataTransfer
+        const file = dataTransfer?.files[0]
+        if (file) {
+          if (
+            file.name.endsWith('.yml') ||
+            file.name.endsWith('.yaml') ||
+            file.name.endsWith('.json') ||
+            file.name.endsWith('.jsonc') ||
+            file.name.endsWith('.json5') ||
+            file.name.endsWith('.txt')
+          ) {
+            try {
+              const path = window.api.webUtils.getPathForFile(file)
+              const content = await readTextFile(path)
+              await addProfileItem({ name: file.name, type: 'local', file: content })
+            } catch (e) {
+              notify('文件导入失败' + e, { variant: 'danger' })
+            }
+          } else {
+            notify('不支持的文件类型', { variant: 'danger' })
           }
         } else {
-          notify('不支持的文件类型', { variant: 'danger' })
+          const droppedUrl =
+            dataTransfer
+              ?.getData('text/uri-list')
+              .split(/\r?\n/)
+              .find((value) => value && !value.startsWith('#')) ||
+            dataTransfer?.getData('text/plain').trim()
+          try {
+            const urlObj = new URL(droppedUrl || '')
+            if (urlObj.protocol !== 'http:' && urlObj.protocol !== 'https:') throw new Error()
+            setEditingItem({
+              id: '',
+              name: '',
+              type: 'remote',
+              url: droppedUrl,
+              useProxy: false,
+              autoUpdate: true
+            })
+            setShowEditModal(true)
+          } catch {
+            notify('未检测到有效的订阅链接', { variant: 'danger' })
+          }
         }
-      } else {
-        const droppedUrl =
-          dataTransfer
-            ?.getData('text/uri-list')
-            .split(/\r?\n/)
-            .find((value) => value && !value.startsWith('#')) ||
-          dataTransfer?.getData('text/plain').trim()
-        try {
-          const urlObj = new URL(droppedUrl || '')
-          if (urlObj.protocol !== 'http:' && urlObj.protocol !== 'https:') throw new Error()
-          setEditingItem({
-            id: '',
-            name: '',
-            type: 'remote',
-            url: droppedUrl,
-            useProxy: false,
-            autoUpdate: true
-          })
-          setShowEditModal(true)
-        } catch {
-          notify('未检测到有效的订阅链接', { variant: 'danger' })
-        }
+      } finally {
+        setFileOver(false)
       }
-      setFileOver(false)
     })
     return (): void => {
       pageRef.current?.removeEventListener('dragover', () => {})


### PR DESCRIPTION
- 修复内核 start/stop/restart 未串行化，快速切换配置/内核或崩溃自动重启时可能产生孤儿内核、或启动 Promise 永不返回卡在“启动中”的问题
- 修复内核不响应 SIGINT 时退出/重启永久挂起的问题
- 修复 log 启动模式下内核在就绪前退出、界面一直卡“启动中”的问题
- 修复 Windows 关机/注销时未能还原系统代理（同步兜底命令传参错误）的问题
- 修复关机时网络检测可能重新开启刚关闭的系统代理的问题
- 修复 macOS 更新失败或取消后系统代理未恢复导致流量直连的问题
- 修复离线开启系统代理后又关闭、恢复网络时被挂起的重试定时器重新开启的问题
- 修复网络检测使用启动时快照配置、外部修改后不生效的问题
- 修复网络检测/系统代理相关未捕获的 Promise 拒绝可能导致主进程崩溃的问题
- 修复进入设置页/资源页返回后误删共享 IPC 监听，导致更新进度、代理组/规则/内核卡片不再刷新的问题
- 修复拖拽非文件内容（文本/链接）到订阅页或覆写页时抛异常卡住的问题
- 修复配置文件编辑器保存失败时无任何提示的问题
- 修复并发授权两个内核时授权 loading 状态相互覆盖的问题
- 修复单次写入配置失败后本次运行内所有设置更改静默失效的问题
- 修复日志写入流未监听 error、磁盘写满等情况下崩溃主进程的问题
- 修复连接页长时间打开时活动时间记录无上限增长的内存问题
- 修复开机自启在路径含 & 等字符时生成非法任务 XML 导致创建失败的问题
- 修复启动时对已过期订阅重复排程更新定时器的问题
- 优化 mac/Linux 上每次内核 API 调用都同步执行 ls 与读盘、测速时阻塞主进程的问题