### PR TITLE
fix: improve profile switching, core readiness and DNS policy overrides

### DIFF
--- a/src/main/core/factory.ts
+++ b/src/main/core/factory.ts
@@ -54,6 +54,11 @@ export async function generateProfile(): Promise<void> {
 
   const profile = deepMerge(JSON.parse(JSON.stringify(currentProfile)), configToMerge)
 
+  if (controlDns && profile.dns) {
+    profile.dns['proxy-server-nameserver-policy'] =
+      configToMerge.dns?.['proxy-server-nameserver-policy'] ?? {}
+  }
+
   await cleanProfile(profile, controlDns, controlSniff)
 
   runtimeConfig = profile

--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -358,7 +358,9 @@ export async function startCore(detached = false): Promise<Promise<void>[]> {
   }
 
   await generateProfile()
-  await checkProfile()
+  if (useServiceCore || detached) {
+    await checkProfile()
+  }
   let serviceCoreRunning = false
   if (useServiceCore) {
     try {
@@ -470,6 +472,26 @@ export async function startCore(detached = false): Promise<Promise<void>[]> {
     env: env
   })
   directCoreState.child = child
+  let startupOutput = ''
+  let configurationRejected = false
+  let spawnError: Error | undefined
+  const captureStartupOutput = (data: Buffer): void => {
+    if (initialized) return
+    startupOutput += data.toString()
+    configurationRejected ||= startupOutput.includes('Parse config error:')
+    startupOutput = startupOutput.slice(-16384)
+  }
+  child.stdout?.on('data', captureStartupOutput)
+  child.stderr?.on('data', captureStartupOutput)
+  child.once('error', (error) => {
+    spawnError = error
+  })
+  const startupFailure = (reason: unknown): Error => {
+    const details = startupOutput.trim()
+    return new Error(
+      `内核启动失败：${spawnError?.message || String(reason)}${details ? `\n${details}` : ''}`
+    )
+  }
   hookWaiter?.attachProcess(child)
   if (child.pid) {
     try {
@@ -487,7 +509,7 @@ export async function startCore(detached = false): Promise<Promise<void>[]> {
   child.on('close', async (code, signal) => {
     flushDirectCoreLogNotifications()
     await appendAppLog(`[Manager]: Core closed, code: ${code}, signal: ${signal}\n`)
-    if (directCoreState.retry) {
+    if (!configurationRejected && directCoreState.retry) {
       await appendAppLog(`[Manager]: Try Restart Core\n`)
       directCoreState.retry--
       await restartCore()
@@ -524,7 +546,7 @@ export async function startCore(detached = false): Promise<Promise<void>[]> {
 
     return new Promise((resolve, reject) => {
       child.once('close', (code, signal) => {
-        reject(new Error(`内核启动失败，code: ${code}, signal: ${signal}`))
+        reject(startupFailure(`code: ${code}, signal: ${signal}`))
       })
 
       child.stdout?.on('data', async (data) => {
@@ -562,7 +584,7 @@ export async function startCore(detached = false): Promise<Promise<void>[]> {
 
               child.once('close', (code, signal) => {
                 if (!initialized) {
-                  reject(new Error(`内核启动失败，code: ${code}, signal: ${signal}`))
+                  reject(startupFailure(`code: ${code}, signal: ${signal}`))
                 }
               })
             })
@@ -587,7 +609,7 @@ export async function startCore(detached = false): Promise<Promise<void>[]> {
           await startMihomoApiStreams()
           resolve([completeCoreInitialization(logLevel)])
         })
-        .catch(reject)
+        .catch((error) => reject(startupFailure(error)))
     })
   }
 

--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -1,4 +1,5 @@
 import { ChildProcess, spawn } from 'child_process'
+import { createInterface } from 'readline'
 import { dataDir, coreLogPath, mihomoCorePath } from '../utils/dirs'
 import { systemCoreOnlyBuild } from '../../shared/build-flags'
 import { generateProfile, getRuntimeConfig } from './factory'
@@ -497,7 +498,9 @@ export async function startCore(detached = false): Promise<Promise<void>[]> {
     try {
       os.setPriority(child.pid, os.constants.priority[mihomoCpuPriority])
     } catch (error) {
-      await appendAppLog(`[Manager]: set core priority failed, ${error}\n`)
+      const log = appendAppLog(`[Manager]: set core priority failed, ${error}\n`)
+      if (detached) await log
+      else void log.catch(() => {})
     }
   }
   if (detached) {
@@ -543,54 +546,45 @@ export async function startCore(detached = false): Promise<Promise<void>[]> {
 
   const waitForCoreReadyByLog = (): Promise<Promise<void>[]> => {
     let controllerReady = false
+    let providersReady = false
+    let completing = false
 
     return new Promise((resolve, reject) => {
+      if (!child.stdout) {
+        reject(startupFailure('Core stdout is unavailable'))
+        return
+      }
+      const lines = createInterface({ input: child.stdout })
       child.once('close', (code, signal) => {
+        lines.close()
         reject(startupFailure(`code: ${code}, signal: ${signal}`))
       })
 
-      child.stdout?.on('data', async (data) => {
-        const str = data.toString()
-        await handleCoreOutput(str, reject)
+      lines.on('line', (line) => {
+        const handleLine = async (): Promise<void> => {
+          await handleCoreOutput(line, reject)
+          if (initialized) return
 
-        if (!controllerReady && isControllerReadyLog(str)) {
-          controllerReady = true
-          resolve([
-            new Promise((resolve, reject) => {
-              const handleProviderInitialization = async (logLine: string): Promise<void> => {
-                providerTracker.track(logLine)
+          providerTracker.track(line)
+          providersReady ||= providerTracker.isReady(line)
+          controllerReady ||= isControllerReadyLog(line)
 
-                if (isTunPermissionError(logLine)) {
-                  patchControledMihomoConfig({ tun: { enable: false } })
-                  mainWindow?.webContents.send('controledMihomoConfigUpdated')
-                  ipcMain.emit('updateTrayMenu')
-                  reject('虚拟网卡启动失败，前往内核设置页尝试手动授予内核权限')
-                }
+          if (isTunPermissionError(line)) {
+            patchControledMihomoConfig({ tun: { enable: false } })
+            mainWindow?.webContents.send('controledMihomoConfigUpdated')
+            ipcMain.emit('updateTrayMenu')
+            reject('虚拟网卡启动失败，前往内核设置页尝试手动授予内核权限')
+            return
+          }
 
-                if (providerTracker.isReady(logLine)) {
-                  await waitForMihomoReady()
-                  initialized = true
-                  completeCoreInitialization(logLevel)
-                    .then(() => resolve())
-                    .catch(reject)
-                }
-              }
-
-              child.stdout?.on('data', (data) => {
-                if (!initialized) {
-                  handleProviderInitialization(data.toString()).catch(reject)
-                }
-              })
-
-              child.once('close', (code, signal) => {
-                if (!initialized) {
-                  reject(startupFailure(`code: ${code}, signal: ${signal}`))
-                }
-              })
-            })
-          ])
+          if (!controllerReady || !providersReady || completing) return
+          completing = true
           await startMihomoApiStreams()
+          await waitForMihomoReady()
+          initialized = true
+          resolve([completeCoreInitialization(logLevel)])
         }
+        handleLine().catch(reject)
       })
     })
   }


### PR DESCRIPTION
## Changes

This PR contains three fixes affecting profile switching, core startup readiness, and runtime configuration generation.

### Reduce profile switching overhead

`34ee3ca` — `fix: reduce profile switching delay`

In my setup, switching profiles often stalls the application for about three seconds. Investigation identified two major sources of overhead:

- Running a separate configuration validation before starting the core.
- GeoSite data decoding and matcher construction in mihomo. These optimizations are submitted separately in [mihomo PR #3185](https://github.com/MetaCubeX/mihomo/pull/3185).

When switching profiles, Sparkle first launches a `mihomo -t` process to validate the configuration, then starts the core. Since normal startup performs the same configuration parsing, this PR removes the separate validation for directly managed core processes and reports configuration errors from the actual startup instead. Service and detached modes retain their separate validation.

For configurations referencing many GeoSite categories, the extra validation can take around 500 ms, depending on the configuration and environment.

The frontend also adds a fixed 500 ms wait after switching profiles. This PR removes that delay as well. I am not sure whether it serves a specific purpose that needs to be preserved; feedback on any such scenarios would be welcome.

### Replace the proxy nameserver policy when overriding DNS

`1bdfa2b` — `fix: replace proxy nameserver policy when overriding DNS`

With DNS overrides enabled, an empty managed `proxy-server-nameserver` array replaces the subscription's resolver list. However, recursively merging an empty `proxy-server-nameserver-policy` object leaves the subscription's policy entries intact. The cleanup step then removes the empty resolver list, producing a runtime configuration rejected by mihomo:

```text
disallow empty `proxy-server-nameserver` when `proxy-server-nameserver-policy` is set
```

With DNS overrides enabled, replace this policy map with the value from the override configuration, including when that value is empty or absent. This follows the DNS UI behavior: the policy editor is shown only when `proxy-server-nameserver` is nonempty, and clearing that list also clears the managed policy. With DNS overrides disabled, the subscription's DNS configuration remains intact.

### Handle core readiness logs in either order

`a173100` — `fix: handle core readiness logs in any order`

In log-based startup detection, the previous implementation only began watching for provider initialization after observing the controller-ready log. Provider initialization can be logged first or arrive in the same stdout chunk as controller readiness. In either case, the notification could be missed, leaving the profile switch pending even though the core was running.

Read complete log lines from the start and track controller and provider readiness independently. Complete initialization once both conditions are satisfied, regardless of their order or stdout chunk boundaries, and guard against starting completion multiple times. The Post Up detection path is unchanged.

## Validation

A [prerelease containing these fixes](https://github.com/Huffer342-WSH/sparkle/releases/tag/geosite-20260906-1) is available for testing and feedback. It also includes the mihomo optimizations mentioned above.

https://github.com/user-attachments/assets/d76ba273-95a7-4864-bb8c-3ccf79bbf435


